### PR TITLE
Add attachment support to PostKit emails

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,34 @@ var email = Email.CreateBuilder()
 await _postKitClient.SendEmailAsync(email);
 ```
 
+#### Attachments and Inline Images
+
+```csharp
+var invoice = Attachment.Create(
+    name: "invoice.pdf",
+    contentType: "application/pdf",
+    content: await File.ReadAllBytesAsync("invoice.pdf"));
+
+var logo = Attachment.Create(
+    name: "logo.png",
+    contentType: "image/png",
+    content: await File.ReadAllBytesAsync("logo.png"),
+    contentId: "logo@yourapp.com");
+
+var email = Email.CreateBuilder()
+    .From("billing@company.com")
+    .To("customer@example.com")
+    .WithSubject("Your Monthly Invoice")
+    .WithHtmlBody($"<p>Please find your invoice attached.</p><img src=\"{logo.ContentId}\" alt=\"Company Logo\" />")
+    .WithAttachment(invoice)
+    .WithAttachment(logo)
+    .Build();
+
+await _postKitClient.SendEmailAsync(email);
+```
+
+> **Note:** Postmark enforces a combined attachment size limit of 10 MB. PostKit automatically enforces this limit when you call `WithAttachment` or `WithAttachments`.
+
 ### Builder Pattern Features
 
 PostKit uses a fluent builder pattern with the following capabilities:

--- a/src/PostKit/Attachment.cs
+++ b/src/PostKit/Attachment.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using MimeKit;
+
+namespace PostKit;
+
+public sealed class Attachment
+{
+    private Attachment(string name, string contentType, string content, int contentLength, string? contentId)
+    {
+        Name = name;
+        ContentType = contentType;
+        Content = content;
+        ContentLength = contentLength;
+        ContentId = contentId;
+    }
+
+    public string Name { get; }
+
+    public string ContentType { get; }
+
+    public string Content { get; }
+
+    public string? ContentId { get; }
+
+    internal int ContentLength { get; }
+
+    public static Attachment Create(string name, string contentType, ReadOnlySpan<byte> content, string? contentId = null)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Attachment name must be specified.", nameof(name));
+
+        if (name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            throw new ArgumentException("Attachment name contains invalid characters.", nameof(name));
+
+        if (string.IsNullOrWhiteSpace(contentType))
+            throw new ArgumentException("Content type must be specified.", nameof(contentType));
+
+        if (!MimeKit.ContentType.TryParse(contentType, out var parsedContentType))
+            throw new ArgumentException("Content type is not a valid MIME type.", nameof(contentType));
+
+        if (content.IsEmpty)
+            throw new ArgumentException("Attachment content cannot be empty.", nameof(content));
+
+        var encodedContent = Convert.ToBase64String(content);
+        var byteLength = content.Length;
+
+        string? normalizedContentId = null;
+        if (contentId is not null)
+        {
+            var trimmedContentId = contentId.Trim();
+
+            if (trimmedContentId.Length == 0)
+                throw new ArgumentException("Content ID cannot be empty or whitespace.", nameof(contentId));
+
+            if (trimmedContentId.StartsWith("cid:", StringComparison.OrdinalIgnoreCase))
+                throw new ArgumentException("Content ID should not include the 'cid:' prefix.", nameof(contentId));
+
+            if (trimmedContentId.Contains('<', StringComparison.Ordinal) || trimmedContentId.Contains('>', StringComparison.Ordinal))
+                throw new ArgumentException("Content ID should not contain angle brackets.", nameof(contentId));
+
+            if (!trimmedContentId.Contains('@', StringComparison.Ordinal))
+                throw new ArgumentException("Content ID must contain an '@' character.", nameof(contentId));
+
+            var candidate = $"cid:{trimmedContentId}";
+            if (!Uri.TryCreate(candidate, UriKind.Absolute, out var uri) || !uri.IsAbsoluteUri)
+                throw new ArgumentException("Content ID is not a valid CID URI.", nameof(contentId));
+
+            normalizedContentId = candidate;
+        }
+
+        return new Attachment(name, parsedContentType.MimeType, encodedContent, byteLength, normalizedContentId);
+    }
+}

--- a/src/PostKit/Common/EmailExtensions.cs
+++ b/src/PostKit/Common/EmailExtensions.cs
@@ -17,6 +17,15 @@ internal static class EmailExtensions
         var bcc = email.Bcc is not null ? string.Join(",", email.Bcc.Select(x => x.ToString(true))) : null;
         var headers = email.Headers?.ToList();
         var metadata = email.Metadata?.ToDictionary();
+        var attachments = email.Attachments?.Select(
+                attachment => new EmailAttachmentRequest
+                {
+                    Name = attachment.Name,
+                    ContentType = attachment.ContentType,
+                    Content = attachment.Content,
+                    ContentId = attachment.ContentId,
+                })
+            .ToList();
         var trackLinks = email.LinkTracking is not null
             ? email.LinkTracking switch
             {
@@ -38,6 +47,7 @@ internal static class EmailExtensions
             Subject = email.Subject,
             HtmlBody = email.HtmlBody,
             TextBody = email.TextBody,
+            Attachments = attachments,
             Tag = email.Tag,
             Headers = headers,
             Metadata = metadata,

--- a/src/PostKit/Email.cs
+++ b/src/PostKit/Email.cs
@@ -32,6 +32,8 @@ public sealed class Email
 
     public string? MessageStream { get; internal init; }
 
+    public IReadOnlyCollection<Attachment>? Attachments { get; internal init; }
+
     internal Email()
     {
     }

--- a/src/PostKit/EmailBuilder.Attachments.cs
+++ b/src/PostKit/EmailBuilder.Attachments.cs
@@ -1,0 +1,62 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace PostKit;
+
+partial class EmailBuilder
+{
+    private const int AttachmentSizeLimitInBytes = 10 * 1024 * 1024;
+    private List<Attachment>? _attachments;
+    private int _attachmentBytes;
+
+    public IEmailBuilder WithAttachment(Attachment attachment)
+    {
+        ArgumentNullException.ThrowIfNull(attachment);
+
+        EnsureAttachmentsWithinLimit(attachment.ContentLength);
+
+        (_attachments ??= new List<Attachment>()).Add(attachment);
+        _attachmentBytes += attachment.ContentLength;
+
+        return this;
+    }
+
+    public IEmailBuilder WithAttachments(IEnumerable<Attachment> attachments)
+    {
+        ArgumentNullException.ThrowIfNull(attachments);
+
+        var buffer = attachments as ICollection<Attachment> ?? attachments.ToList();
+        if (buffer.Count == 0)
+            return this;
+
+        long additionalBytes = 0;
+        foreach (var attachment in buffer)
+        {
+            ArgumentNullException.ThrowIfNull(attachment);
+            additionalBytes += attachment.ContentLength;
+        }
+
+        EnsureAttachmentsWithinLimit(additionalBytes);
+
+        (_attachments ??= new List<Attachment>()).AddRange(buffer);
+        _attachmentBytes += (int)additionalBytes;
+
+        return this;
+    }
+
+    internal void EnsureAttachmentConstraints()
+    {
+        EnsureAttachmentsWithinLimit(0);
+    }
+
+    private void EnsureAttachmentsWithinLimit(long additionalBytes)
+    {
+        if (additionalBytes < 0)
+            throw new ArgumentOutOfRangeException(nameof(additionalBytes));
+
+        var projectedTotal = (long)_attachmentBytes + additionalBytes;
+        if (projectedTotal > AttachmentSizeLimitInBytes)
+            throw new InvalidOperationException("Attachments exceed Postmark's 10 MB limit.");
+    }
+}

--- a/src/PostKit/EmailBuilder.cs
+++ b/src/PostKit/EmailBuilder.cs
@@ -24,6 +24,8 @@ public sealed partial class EmailBuilder : IEmailBuilder
         if (_htmlBody is null && _textBody is null)
             throw new InvalidOperationException("Either an HTML or text body is required.");
 
+        EnsureAttachmentConstraints();
+
         var email = new Email
         {
             From = _from,
@@ -39,6 +41,7 @@ public sealed partial class EmailBuilder : IEmailBuilder
             Metadata = _metadata?.AsReadOnly(),
             LinkTracking = _linkTracking,
             MessageStream = _messageStream,
+            Attachments = _attachments?.AsReadOnly(),
         };
 
         return email;

--- a/src/PostKit/IEmailBuilder.cs
+++ b/src/PostKit/IEmailBuilder.cs
@@ -42,6 +42,8 @@ public interface IEmailBuilder
     IEmailBuilder WithMetadata(KeyValuePair<string, string> entry);
     IEmailBuilder WithMetadata(IEnumerable<KeyValuePair<string, string>> metadata);
     IEmailBuilder WithMetadata(IDictionary<string, string> metadata);
+    IEmailBuilder WithAttachment(Attachment attachment);
+    IEmailBuilder WithAttachments(IEnumerable<Attachment> attachments);
     IEmailBuilder WithOpenTracking(bool openTracking = true);
     IEmailBuilder WithLinkTracking(LinkTracking linkTracking = LinkTracking.HtmlAndText);
     IEmailBuilder UsingMessageStream(MessageStream messageStream);


### PR DESCRIPTION
## Summary
- introduce a validated Attachment value object that stores base64 content and optional normalized content IDs
- extend the email builder, email model, and request mapping to carry attachments while enforcing Postmark's 10 MB limit
- document how to create attachments and embed inline images with ContentId helpers

## Testing
- not run (dotnet CLI is unavailable in the execution environment)


------
https://chatgpt.com/codex/tasks/task_e_68e67c2a11dc8328966a495e2e5ce56d