### PR TITLE
Ensure string message stream is applied to email request

### DIFF
--- a/PostKit.sln
+++ b/PostKit.sln
@@ -6,6 +6,10 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{83B35624
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PostKit", "src\PostKit\PostKit.csproj", "{C9D7514E-34AE-45A3-980B-84DBD5120BF2}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{CD3A7C84-7F22-4650-812A-793C8BC05E41}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PostKit.Tests", "tests\\PostKit.Tests\\PostKit.Tests.csproj", "{5CD4FC31-A455-40B3-82E7-E77658771A04}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -20,8 +24,13 @@ Global
 		{C9D7514E-34AE-45A3-980B-84DBD5120BF2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{C9D7514E-34AE-45A3-980B-84DBD5120BF2}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{C9D7514E-34AE-45A3-980B-84DBD5120BF2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5CD4FC31-A455-40B3-82E7-E77658771A04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5CD4FC31-A455-40B3-82E7-E77658771A04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5CD4FC31-A455-40B3-82E7-E77658771A04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5CD4FC31-A455-40B3-82E7-E77658771A04}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{4C9C196B-46C2-461E-AD67-1C2A71E28084} = {83B35624-97C6-4EF6-A198-552522CC5662}
+		{5CD4FC31-A455-40B3-82E7-E77658771A04} = {CD3A7C84-7F22-4650-812A-793C8BC05E41}
 	EndGlobalSection
 EndGlobal

--- a/src/PostKit/EmailBuilder.MessageStream.cs
+++ b/src/PostKit/EmailBuilder.MessageStream.cs
@@ -28,6 +28,8 @@ partial class EmailBuilder
         if (!IsValidMessageStreamId(messageStreamId))
             throw new ArgumentException("The message stream ID is invalid.", nameof(messageStreamId));
 
+        _messageStream = messageStreamId;
+
         return this;
     }
 

--- a/src/PostKit/Properties/AssemblyInfo.cs
+++ b/src/PostKit/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("PostKit.Tests")]

--- a/tests/PostKit.Tests/EmailBuilderMessageStreamTests.cs
+++ b/tests/PostKit.Tests/EmailBuilderMessageStreamTests.cs
@@ -1,0 +1,25 @@
+using PostKit;
+using PostKit.Common;
+using Xunit;
+
+namespace PostKit.Tests;
+
+public class EmailBuilderMessageStreamTests
+{
+    [Fact]
+    public void UsingMessageStream_WithString_SetsMessageStreamOnEmailRequest()
+    {
+        const string messageStreamId = "custom-stream-id";
+
+        var email = Email.CreateBuilder()
+            .From("sender@example.com")
+            .To("recipient@example.com")
+            .WithHtmlBody("<p>Hello</p>")
+            .UsingMessageStream(messageStreamId)
+            .Build();
+
+        var request = email.ToEmailRequest();
+
+        Assert.Equal(messageStreamId, request.MessageStream);
+    }
+}

--- a/tests/PostKit.Tests/PostKit.Tests.csproj
+++ b/tests/PostKit.Tests/PostKit.Tests.csproj
@@ -1,0 +1,19 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageReference Include="coverlet.collector" Version="6.0.3" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\PostKit\PostKit.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
## Summary
- set the string-based message stream on the email builder after validating the identifier
- expose internals for testing and add a dedicated xUnit test project
- add a regression test that ensures EmailRequest.MessageStream matches the provided stream ID

## Testing
- `dotnet test` *(fails: dotnet CLI is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed0f10747c83289210f71cff0dfacc