### PR TITLE
Fix email body size limit calculation

### DIFF
--- a/src/PostKit/EmailBuilder.cs
+++ b/src/PostKit/EmailBuilder.cs
@@ -26,7 +26,7 @@ public sealed partial class EmailBuilder : IEmailBuilder
         if (_htmlBody is null && _textBody is null && !_templateId.HasValue && _templateAlias is null)
             throw new InvalidOperationException("Either an HTML or text body, or a template ID or alias, is required.");
 
-        var bodyLength = (long)(_textBody?.Length + _htmlBody?.Length ?? 0);
+        var bodyLength = (long)(_textBody?.Length ?? 0) + (_htmlBody?.Length ?? 0);
         var projectedTotal = _attachmentBytes + bodyLength;
         if (projectedTotal > MessageSizeLimitInBytes)
             throw new InvalidOperationException("Message size exceeds Postmark's 10 MB limit.");

--- a/tests/PostKit.Tests/EmailBuilderSizeLimitTests.cs
+++ b/tests/PostKit.Tests/EmailBuilderSizeLimitTests.cs
@@ -1,0 +1,22 @@
+using System;
+using PostKit;
+using Xunit;
+
+namespace PostKit.Tests;
+
+public class EmailBuilderSizeLimitTests
+{
+    [Fact]
+    public void Build_WithOversizedTextBody_ThrowsInvalidOperationException()
+    {
+        const int messageSizeLimit = 10 * 1024 * 1024;
+        var oversizedText = new string('a', messageSizeLimit + 1);
+
+        var builder = Email.CreateBuilder()
+            .From("sender@example.com")
+            .To("recipient@example.com")
+            .WithTextBody(oversizedText);
+
+        Assert.Throws<InvalidOperationException>(() => builder.Build());
+    }
+}


### PR DESCRIPTION
## Summary
- ensure the email size calculation includes both the text and HTML bodies independently
- add a regression test that verifies an oversized text-only email triggers the size limit exception

## Testing
- dotnet test *(fails in container: `dotnet` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ed29a19a688328813a16b2dbb3a50d