### PR TITLE
Dispose HttpClient responses in Postmark client

### DIFF
--- a/src/PostKit/Postmark/PostmarkClient.cs
+++ b/src/PostKit/Postmark/PostmarkClient.cs
@@ -62,9 +62,9 @@ internal sealed
         var jsonToSend = JsonSerializer.Serialize(body, _jsonSerializerOptions);
         LogApiRequest(jsonToSend);
         var contentToSend = new StringContent(jsonToSend, Encoding.UTF8, MediaTypeNames.Application.Json);
-        var responseMessage = await _httpClient.PostAsync(endpoint, contentToSend, cancellationToken);
+        using var responseMessage = await _httpClient.PostAsync(endpoint, contentToSend, cancellationToken);
 #else
-        var responseMessage = await _httpClient.PostAsJsonAsync(endpoint, body, _jsonSerializerOptions, cancellationToken);
+        using var responseMessage = await _httpClient.PostAsJsonAsync(endpoint, body, _jsonSerializerOptions, cancellationToken);
 #endif
         if (responseMessage.IsSuccessStatusCode)
         {


### PR DESCRIPTION
## Summary
- dispose the HttpClient response message returned by PostmarkClient.SendAsync using a using declaration for both debug and release builds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed29a41e6483289c872c55992f9c9c