### PR TITLE
Update header duplicate exception message

### DIFF
--- a/src/PostKit/EmailBuilder.Header.cs
+++ b/src/PostKit/EmailBuilder.Header.cs
@@ -57,7 +57,7 @@ partial class EmailBuilder
             .Distinct(StringComparer.OrdinalIgnoreCase)
             .Count();
         if (uniqueKeys != headers.Keys.Count)
-            throw new ArgumentException("There are duplicate metadata entries.", nameof(headers));
+            throw new ArgumentException("There are duplicate header entries.", nameof(headers));
 
         foreach (var header in headers)
             ValidateHeader(header.Key, header.Value, nameof(headers));

--- a/tests/PostKit.Tests/EmailBuilderHeaderTests.cs
+++ b/tests/PostKit.Tests/EmailBuilderHeaderTests.cs
@@ -1,0 +1,23 @@
+using System.Collections.Generic;
+using PostKit;
+using Xunit;
+
+namespace PostKit.Tests;
+
+public class EmailBuilderHeaderTests
+{
+    [Fact]
+    public void WithHeader_DuplicateDictionaryKeys_ThrowsArgumentExceptionWithHeaderMessage()
+    {
+        var builder = Email.CreateBuilder();
+        var headers = new Dictionary<string, string>
+        {
+            ["X-Test"] = "A",
+            ["x-test"] = "B",
+        };
+
+        var exception = Assert.Throws<ArgumentException>(() => builder.WithHeader(headers));
+
+        Assert.Equal("There are duplicate header entries. (Parameter 'headers')", exception.Message);
+    }
+}


### PR DESCRIPTION
## Summary
- update the duplicate header dictionary guard to report "There are duplicate header entries."
- add a unit test covering the duplicate dictionary key scenario and asserting the new message

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ed29b3c25083288f99bf53ea814b02