### PR TITLE
Add XML documentation to core PostKit types

### DIFF
--- a/src/PostKit/Attachment.cs
+++ b/src/PostKit/Attachment.cs
@@ -1,5 +1,8 @@
 namespace PostKit;
 
+/// <summary>
+/// Represents an email attachment that can be sent with a <see cref="Email"/>.
+/// </summary>
 public sealed class Attachment
 {
     private Attachment(string name, string contentType, string content, string? contentId)
@@ -10,14 +13,35 @@ public sealed class Attachment
         ContentId = contentId;
     }
 
+    /// <summary>
+    /// Gets the file name that will be presented to the email recipient.
+    /// </summary>
     public string Name { get; }
 
+    /// <summary>
+    /// Gets the MIME content type of the attachment.
+    /// </summary>
     public string ContentType { get; }
 
+    /// <summary>
+    /// Gets the Base64 encoded contents of the attachment.
+    /// </summary>
     public string Content { get; }
 
+    /// <summary>
+    /// Gets the optional content identifier of the attachment when it should be embedded in the message body.
+    /// </summary>
     public string? ContentId { get; }
 
+    /// <summary>
+    /// Creates a new <see cref="Attachment"/> from the provided raw content.
+    /// </summary>
+    /// <param name="name">The file name to associate with the attachment.</param>
+    /// <param name="contentType">The MIME content type describing the attachment.</param>
+    /// <param name="content">The raw attachment content that will be encoded as Base64.</param>
+    /// <param name="contentId">The optional content identifier used for inline attachments.</param>
+    /// <returns>The created <see cref="Attachment"/>.</returns>
+    /// <exception cref="ArgumentException">Thrown when any parameter is invalid.</exception>
     public static Attachment Create(string name, string contentType, ReadOnlySpan<byte> content, string? contentId = null)
     {
         if (string.IsNullOrWhiteSpace(name))

--- a/src/PostKit/Configuration/PostKitOptions.cs
+++ b/src/PostKit/Configuration/PostKitOptions.cs
@@ -1,7 +1,17 @@
-﻿namespace PostKit.Configuration;
+namespace PostKit.Configuration;
 
+/// <summary>
+/// Represents configuration settings used to access the PostKit/Postmark API.
+/// </summary>
 public sealed class PostKitOptions
 {
+    /// <summary>
+    /// Gets the API token used for account level operations.
+    /// </summary>
     public string? AccountApiToken { get; init; }
+
+    /// <summary>
+    /// Gets the API token used for server level operations.
+    /// </summary>
     public string? ServerApiToken { get; init; }
 }

--- a/src/PostKit/Email.cs
+++ b/src/PostKit/Email.cs
@@ -2,50 +2,114 @@
 
 namespace PostKit;
 
+/// <summary>
+/// Represents an email message that can be composed and sent through PostKit.
+/// </summary>
 public sealed class Email
 {
+    /// <summary>
+    /// Gets the sender of the email.
+    /// </summary>
     public MailboxAddress? From { get; internal init; }
 
+    /// <summary>
+    /// Gets the reply-to recipients for the email.
+    /// </summary>
     public IReadOnlyCollection<MailboxAddress>? ReplyTo { get; internal init; }
 
+    /// <summary>
+    /// Gets the primary recipients of the email.
+    /// </summary>
     public IReadOnlyCollection<MailboxAddress>? To { get; internal init; }
 
+    /// <summary>
+    /// Gets the carbon-copy recipients of the email.
+    /// </summary>
     public IReadOnlyCollection<MailboxAddress>? Cc { get; internal init; }
 
+    /// <summary>
+    /// Gets the blind-carbon-copy recipients of the email.
+    /// </summary>
     public IReadOnlyCollection<MailboxAddress>? Bcc { get; internal init; }
 
+    /// <summary>
+    /// Gets the subject line of the email.
+    /// </summary>
     public string? Subject { get; internal init; }
 
+    /// <summary>
+    /// Gets the HTML body of the email.
+    /// </summary>
     public string? HtmlBody { get; internal init; }
 
+    /// <summary>
+    /// Gets the plain text body of the email.
+    /// </summary>
     public string? TextBody { get; internal init; }
 
+    /// <summary>
+    /// Gets the optional tag used to categorize the email in Postmark.
+    /// </summary>
     public string? Tag { get; internal init; }
 
+    /// <summary>
+    /// Gets the custom headers applied to the email.
+    /// </summary>
     public IReadOnlyDictionary<string, string>? Headers { get; internal init; }
 
+    /// <summary>
+    /// Gets the metadata that accompanies the email.
+    /// </summary>
     public IReadOnlyDictionary<string, string>? Metadata { get; internal init; }
 
+    /// <summary>
+    /// Gets a value indicating whether open tracking is enabled for the email.
+    /// </summary>
     public bool? OpenTracking { get; internal init; }
 
+    /// <summary>
+    /// Gets the link tracking mode applied to the email.
+    /// </summary>
     public LinkTracking? LinkTracking { get; internal init; }
 
+    /// <summary>
+    /// Gets the message stream the email will be sent through.
+    /// </summary>
     public string? MessageStream { get; internal init; }
 
+    /// <summary>
+    /// Gets the attachments that will be sent with the email.
+    /// </summary>
     public IReadOnlyCollection<Attachment>? Attachments { get; internal init; }
-    
+
+    /// <summary>
+    /// Gets the Postmark template identifier to use when sending the email.
+    /// </summary>
     public int? TemplateId { get; internal init; }
-    
+
+    /// <summary>
+    /// Gets the Postmark template alias to use when sending the email.
+    /// </summary>
     public string? TemplateAlias { get; internal init; }
-    
+
+    /// <summary>
+    /// Gets the model that will be merged into the email template.
+    /// </summary>
     public object? TemplateModel { get; internal init; }
-    
+
+    /// <summary>
+    /// Gets a value indicating whether CSS should be inlined when sending the email.
+    /// </summary>
     public bool? InlineCss { get; internal init; }
 
     internal Email()
     {
     }
 
+    /// <summary>
+    /// Creates a new <see cref="EmailBuilder"/> for composing an <see cref="Email"/>.
+    /// </summary>
+    /// <returns>A builder that can be used to configure an email.</returns>
     public static EmailBuilder CreateBuilder()
     {
         return new EmailBuilder();

--- a/src/PostKit/LinkTracking.cs
+++ b/src/PostKit/LinkTracking.cs
@@ -1,9 +1,27 @@
-﻿namespace PostKit;
+namespace PostKit;
 
+/// <summary>
+/// Represents the available link tracking modes supported by Postmark.
+/// </summary>
 public enum LinkTracking
 {
+    /// <summary>
+    /// Disables link tracking.
+    /// </summary>
     None = 0,
+
+    /// <summary>
+    /// Enables link tracking for both HTML and plain text bodies.
+    /// </summary>
     HtmlAndText = 1,
+
+    /// <summary>
+    /// Enables link tracking for the HTML body only.
+    /// </summary>
     HtmlOnly = 2,
+
+    /// <summary>
+    /// Enables link tracking for the plain text body only.
+    /// </summary>
     TextOnly = 3,
 }

--- a/src/PostKit/MessageStream.cs
+++ b/src/PostKit/MessageStream.cs
@@ -1,10 +1,20 @@
-﻿using System.Diagnostics.CodeAnalysis;
+using System.Diagnostics.CodeAnalysis;
 
 namespace PostKit;
 
-[SuppressMessage("Naming", "CA1711: Identifiers should not have incorrect suffix", Justification = "Postmark calls it a MessageStream, CA1711. You’re the one making it awkward.")]
+/// <summary>
+/// Identifies the Postmark message stream that an email should be sent through.
+/// </summary>
+[SuppressMessage("Naming", "CA1711: Identifiers should not have incorrect suffix", Justification = "Postmark calls it a MessageStream, CA1711. You're the one making it awkward.")]
 public enum MessageStream
 {
+    /// <summary>
+    /// Represents the transactional message stream.
+    /// </summary>
     Transactional = 0,
+
+    /// <summary>
+    /// Represents the broadcast message stream.
+    /// </summary>
     Broadcast = 1,
 }

--- a/src/PostKit/PostKitExtensions.cs
+++ b/src/PostKit/PostKitExtensions.cs
@@ -4,8 +4,15 @@ using PostKit.Postmark;
 
 namespace PostKit;
 
+/// <summary>
+/// Provides dependency injection helpers for registering PostKit services.
+/// </summary>
 public static class PostKitExtensions
 {
+    /// <summary>
+    /// Registers the services required to send email through PostKit.
+    /// </summary>
+    /// <param name="services">The service collection to configure.</param>
     public static void AddPostKit(this IServiceCollection services)
     {
         services.AddHttpClient();

--- a/src/PostKit/Responses/SendEmailResponse.cs
+++ b/src/PostKit/Responses/SendEmailResponse.cs
@@ -1,11 +1,21 @@
-﻿using JetBrains.Annotations;
+using JetBrains.Annotations;
 
 namespace PostKit.Responses;
 
+/// <summary>
+/// Represents the response returned after Postmark accepts an email for delivery.
+/// </summary>
 public sealed record SendEmailResponse
 {
+    /// <summary>
+    /// Gets the identifier assigned to the accepted message.
+    /// </summary>
     public string MessageId { [UsedImplicitly] get; }
 
+    /// <summary>
+    /// Initializes a new instance of the <see cref="SendEmailResponse"/> class.
+    /// </summary>
+    /// <param name="messageId">The identifier returned by Postmark for the message.</param>
     internal SendEmailResponse(string messageId)
     {
         MessageId = $"<{messageId}@mtasv.net>";


### PR DESCRIPTION
## Summary
- add Microsoft-style XML documentation comments to Attachment, Email, LinkTracking, MessageStream, PostKitOptions, PostKitExtensions, and SendEmailResponse to describe the public API

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68ed2ddc8db88328b7b8637c56b9ab58