### PR TITLE
Add IEnumerable overloads to EmailBuilder mailbox methods

### DIFF
--- a/src/PostKit/EmailBuilder.Bcc.cs
+++ b/src/PostKit/EmailBuilder.Bcc.cs
@@ -48,6 +48,23 @@ partial class EmailBuilder : IEmailBccBuilder
     }
 
     /// <inheritdoc />
+    public IEmailBccBuilder Bcc(IEnumerable<MailboxAddress> mailboxAddresses)
+    {
+        _bcc.EnsureNotSet(nameof(Email.Bcc));
+
+        var addresses = new List<MailboxAddress>();
+
+        foreach (var mailboxAddress in mailboxAddresses)
+        {
+            addresses.Add(mailboxAddress);
+        }
+
+        _bcc = addresses;
+
+        return this;
+    }
+
+    /// <inheritdoc />
     public IEmailBccBuilder Bcc(IList<MailboxAddress> mailboxAddresses)
     {
         _bcc.EnsureNotSet(nameof(Email.Bcc));
@@ -93,6 +110,17 @@ partial class EmailBuilder : IEmailBccBuilder
         var mailboxAddresses = addresses.ToAddressList();
 
         _bcc!.AddRange(mailboxAddresses);
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IEmailBccBuilder AlsoBcc(IEnumerable<MailboxAddress> mailboxAddresses)
+    {
+        foreach (var mailboxAddress in mailboxAddresses)
+        {
+            _bcc!.Add(mailboxAddress);
+        }
 
         return this;
     }

--- a/src/PostKit/EmailBuilder.Cc.cs
+++ b/src/PostKit/EmailBuilder.Cc.cs
@@ -48,6 +48,23 @@ partial class EmailBuilder : IEmailCcBuilder
     }
 
     /// <inheritdoc />
+    public IEmailCcBuilder Cc(IEnumerable<MailboxAddress> mailboxAddresses)
+    {
+        _cc.EnsureNotSet(nameof(Email.Cc));
+
+        var addresses = new List<MailboxAddress>();
+
+        foreach (var mailboxAddress in mailboxAddresses)
+        {
+            addresses.Add(mailboxAddress);
+        }
+
+        _cc = addresses;
+
+        return this;
+    }
+
+    /// <inheritdoc />
     public IEmailCcBuilder Cc(IList<MailboxAddress> mailboxAddresses)
     {
         _cc.EnsureNotSet(nameof(Email.Cc));
@@ -93,6 +110,17 @@ partial class EmailBuilder : IEmailCcBuilder
         var mailboxAddresses = addresses.ToAddressList();
 
         _cc!.AddRange(mailboxAddresses);
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IEmailCcBuilder AlsoCc(IEnumerable<MailboxAddress> mailboxAddresses)
+    {
+        foreach (var mailboxAddress in mailboxAddresses)
+        {
+            _cc!.Add(mailboxAddress);
+        }
 
         return this;
     }

--- a/src/PostKit/EmailBuilder.ReplyTo.cs
+++ b/src/PostKit/EmailBuilder.ReplyTo.cs
@@ -48,6 +48,23 @@ partial class EmailBuilder : IEmailReplyToBuilder
     }
 
     /// <inheritdoc />
+    public IEmailReplyToBuilder ReplyTo(IEnumerable<MailboxAddress> mailboxAddresses)
+    {
+        _replyTo.EnsureNotSet(nameof(Email.ReplyTo));
+
+        var addresses = new List<MailboxAddress>();
+
+        foreach (var mailboxAddress in mailboxAddresses)
+        {
+            addresses.Add(mailboxAddress);
+        }
+
+        _replyTo = addresses;
+
+        return this;
+    }
+
+    /// <inheritdoc />
     public IEmailReplyToBuilder ReplyTo(IList<MailboxAddress> mailboxAddresses)
     {
         _replyTo.EnsureNotSet(nameof(Email.ReplyTo));
@@ -93,6 +110,17 @@ partial class EmailBuilder : IEmailReplyToBuilder
         var mailboxAddresses = addresses.ToAddressList();
 
         _replyTo!.AddRange(mailboxAddresses);
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IEmailReplyToBuilder AlsoReplyTo(IEnumerable<MailboxAddress> mailboxAddresses)
+    {
+        foreach (var mailboxAddress in mailboxAddresses)
+        {
+            _replyTo!.Add(mailboxAddress);
+        }
 
         return this;
     }

--- a/src/PostKit/EmailBuilder.To.cs
+++ b/src/PostKit/EmailBuilder.To.cs
@@ -48,6 +48,23 @@ partial class EmailBuilder : IEmailToBuilder
     }
 
     /// <inheritdoc />
+    public IEmailToBuilder To(IEnumerable<MailboxAddress> mailboxAddresses)
+    {
+        _to.EnsureNotSet(nameof(Email.To));
+
+        var addresses = new List<MailboxAddress>();
+
+        foreach (var mailboxAddress in mailboxAddresses)
+        {
+            addresses.Add(mailboxAddress);
+        }
+
+        _to = addresses;
+
+        return this;
+    }
+
+    /// <inheritdoc />
     public IEmailToBuilder To(IList<MailboxAddress> mailboxAddresses)
     {
         _to.EnsureNotSet(nameof(Email.To));
@@ -93,6 +110,17 @@ partial class EmailBuilder : IEmailToBuilder
         var mailboxAddresses = addresses.ToAddressList();
 
         _to!.AddRange(mailboxAddresses);
+
+        return this;
+    }
+
+    /// <inheritdoc />
+    public IEmailToBuilder AlsoTo(IEnumerable<MailboxAddress> mailboxAddresses)
+    {
+        foreach (var mailboxAddress in mailboxAddresses)
+        {
+            _to!.Add(mailboxAddress);
+        }
 
         return this;
     }

--- a/src/PostKit/IEmailBccBuilder.cs
+++ b/src/PostKit/IEmailBccBuilder.cs
@@ -41,5 +41,12 @@ public interface IEmailBccBuilder : IEmailBuilder
     /// </summary>
     /// <param name="mailboxAddresses">The BCC mailbox addresses.</param>
     /// <returns>The builder instance for fluent chaining.</returns>
+    IEmailBccBuilder AlsoBcc(IEnumerable<MailboxAddress> mailboxAddresses);
+
+    /// <summary>
+    /// Adds multiple blind carbon-copy recipients using mailbox addresses.
+    /// </summary>
+    /// <param name="mailboxAddresses">The BCC mailbox addresses.</param>
+    /// <returns>The builder instance for fluent chaining.</returns>
     IEmailBccBuilder AlsoBcc(IList<MailboxAddress> mailboxAddresses);
 }

--- a/src/PostKit/IEmailBuilder.cs
+++ b/src/PostKit/IEmailBuilder.cs
@@ -71,6 +71,13 @@ public interface IEmailBuilder
     /// </summary>
     /// <param name="mailboxAddresses">The reply-to mailbox addresses.</param>
     /// <returns>An <see cref="IEmailReplyToBuilder"/> for further configuration.</returns>
+    IEmailReplyToBuilder ReplyTo(IEnumerable<MailboxAddress> mailboxAddresses);
+
+    /// <summary>
+    /// Begins configuring reply-to recipients with mailbox addresses.
+    /// </summary>
+    /// <param name="mailboxAddresses">The reply-to mailbox addresses.</param>
+    /// <returns>An <see cref="IEmailReplyToBuilder"/> for further configuration.</returns>
     IEmailReplyToBuilder ReplyTo(IList<MailboxAddress> mailboxAddresses);
 
     /// <summary>
@@ -101,6 +108,13 @@ public interface IEmailBuilder
     /// <param name="addresses">The recipient email addresses.</param>
     /// <returns>An <see cref="IEmailToBuilder"/> for further configuration.</returns>
     IEmailToBuilder To(IEnumerable<string> addresses);
+
+    /// <summary>
+    /// Begins configuring primary recipients with mailbox addresses.
+    /// </summary>
+    /// <param name="mailboxAddresses">The recipient mailbox addresses.</param>
+    /// <returns>An <see cref="IEmailToBuilder"/> for further configuration.</returns>
+    IEmailToBuilder To(IEnumerable<MailboxAddress> mailboxAddresses);
 
     /// <summary>
     /// Begins configuring primary recipients with mailbox addresses.
@@ -143,6 +157,13 @@ public interface IEmailBuilder
     /// </summary>
     /// <param name="mailboxAddresses">The CC mailbox addresses.</param>
     /// <returns>An <see cref="IEmailCcBuilder"/> for further configuration.</returns>
+    IEmailCcBuilder Cc(IEnumerable<MailboxAddress> mailboxAddresses);
+
+    /// <summary>
+    /// Begins configuring carbon-copy recipients with mailbox addresses.
+    /// </summary>
+    /// <param name="mailboxAddresses">The CC mailbox addresses.</param>
+    /// <returns>An <see cref="IEmailCcBuilder"/> for further configuration.</returns>
     IEmailCcBuilder Cc(IList<MailboxAddress> mailboxAddresses);
 
     /// <summary>
@@ -173,6 +194,13 @@ public interface IEmailBuilder
     /// <param name="addresses">The BCC email addresses.</param>
     /// <returns>An <see cref="IEmailBccBuilder"/> for further configuration.</returns>
     IEmailBccBuilder Bcc(IEnumerable<string> addresses);
+
+    /// <summary>
+    /// Begins configuring blind carbon-copy recipients with mailbox addresses.
+    /// </summary>
+    /// <param name="mailboxAddresses">The BCC mailbox addresses.</param>
+    /// <returns>An <see cref="IEmailBccBuilder"/> for further configuration.</returns>
+    IEmailBccBuilder Bcc(IEnumerable<MailboxAddress> mailboxAddresses);
 
     /// <summary>
     /// Begins configuring blind carbon-copy recipients with mailbox addresses.

--- a/src/PostKit/IEmailCcBuilder.cs
+++ b/src/PostKit/IEmailCcBuilder.cs
@@ -41,5 +41,12 @@ public interface IEmailCcBuilder : IEmailBuilder
     /// </summary>
     /// <param name="mailboxAddresses">The CC mailbox addresses.</param>
     /// <returns>The builder instance for fluent chaining.</returns>
+    IEmailCcBuilder AlsoCc(IEnumerable<MailboxAddress> mailboxAddresses);
+
+    /// <summary>
+    /// Adds multiple carbon-copy recipients using mailbox addresses.
+    /// </summary>
+    /// <param name="mailboxAddresses">The CC mailbox addresses.</param>
+    /// <returns>The builder instance for fluent chaining.</returns>
     IEmailCcBuilder AlsoCc(IList<MailboxAddress> mailboxAddresses);
 }

--- a/src/PostKit/IEmailReplyToBuilder.cs
+++ b/src/PostKit/IEmailReplyToBuilder.cs
@@ -41,5 +41,12 @@ public interface IEmailReplyToBuilder : IEmailBuilder
     /// </summary>
     /// <param name="mailboxAddresses">The reply-to mailbox addresses.</param>
     /// <returns>The builder instance for fluent chaining.</returns>
+    IEmailReplyToBuilder AlsoReplyTo(IEnumerable<MailboxAddress> mailboxAddresses);
+
+    /// <summary>
+    /// Adds multiple reply-to recipients using mailbox addresses.
+    /// </summary>
+    /// <param name="mailboxAddresses">The reply-to mailbox addresses.</param>
+    /// <returns>The builder instance for fluent chaining.</returns>
     IEmailReplyToBuilder AlsoReplyTo(IList<MailboxAddress> mailboxAddresses);
 }

--- a/src/PostKit/IEmailToBuilder.cs
+++ b/src/PostKit/IEmailToBuilder.cs
@@ -41,5 +41,12 @@ public interface IEmailToBuilder : IEmailBuilder
     /// </summary>
     /// <param name="mailboxAddresses">The recipient mailbox addresses.</param>
     /// <returns>The builder instance for fluent chaining.</returns>
+    IEmailToBuilder AlsoTo(IEnumerable<MailboxAddress> mailboxAddresses);
+
+    /// <summary>
+    /// Adds multiple primary recipients using mailbox addresses.
+    /// </summary>
+    /// <param name="mailboxAddresses">The recipient mailbox addresses.</param>
+    /// <returns>The builder instance for fluent chaining.</returns>
     IEmailToBuilder AlsoTo(IList<MailboxAddress> mailboxAddresses);
 }


### PR DESCRIPTION
## Summary
- add IEnumerable<MailboxAddress> overloads to EmailBuilder's ReplyTo, To, Cc, and Bcc methods and their Also variants
- expose matching overloads on the related builder interfaces for fluent chaining without reallocating IList inputs

## Testing
- dotnet test *(fails: dotnet CLI not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ed5e8e54d08328a6a46f6bd3ed4b74