### PR TITLE
Add .NET 9/10 multi-targeting and dependency updates

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -24,10 +24,12 @@ jobs:
         with:
           languages: 'csharp'
 
-      - name: Setup .NET 9.0
+      - name: Setup .NET 9.0 and 10.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.x
+          dotnet-version: |
+            9.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore
@@ -36,7 +38,7 @@ jobs:
         run: dotnet build --configuration Release --no-restore
 
       - name: Test
-        run: dotnet test --configuration Release --no-build --verbosity normal --framework net9.0
+        run: dotnet test --configuration Release --no-build --verbosity normal
 
       - name: Perform CodeQL analysis
         uses: github/codeql-action/analyze@v3

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,10 +17,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Setup .NET 9.0
+      - name: Setup .NET 9.0 and 10.0
         uses: actions/setup-dotnet@v4
         with:
-          dotnet-version: 9.x
+          dotnet-version: |
+            9.0.x
+            10.0.x
 
       - name: Restore dependencies
         run: dotnet restore

--- a/src/PostKit/PostKit.csproj
+++ b/src/PostKit/PostKit.csproj
@@ -3,7 +3,7 @@
     <!-- Compilation -->
     <PropertyGroup>
         <RootNamespace>PostKit</RootNamespace>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <LangVersion>latest</LangVersion>
@@ -18,7 +18,7 @@
     <!-- References -->
     <ItemGroup>
         <PackageReference Include="JetBrains.Annotations" Version="2025.2.2"/>
-        <PackageReference Include="LightResults" Version="9.0.5"/>
+        <PackageReference Include="LightResults" Version="10.0.0"/>
         <PackageReference Include="Microsoft.Extensions.Http" Version="9.0.9"/>
         <PackageReference Include="Microsoft.Extensions.Telemetry.Abstractions" Version="9.9.0"/>
         <PackageReference Include="MimeKit" Version="4.14.0"/>
@@ -27,9 +27,9 @@
     <!-- Output -->
     <PropertyGroup>
         <AssemblyName>PostKit</AssemblyName>
-        <Version>9.0.0-preview.7</Version>
-        <AssemblyVersion>9.0.0.0</AssemblyVersion>
-        <FileVersion>9.0.0.0</FileVersion>
+        <Version>10.0.0-preview.1</Version>
+        <AssemblyVersion>10.0.0.0</AssemblyVersion>
+        <FileVersion>10.0.0.0</FileVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <Optimize>true</Optimize>
         <!--<IsAotCompatible>true</IsAotCompatible>-->

--- a/tests/PostKit.Tests/PostKit.Tests.csproj
+++ b/tests/PostKit.Tests/PostKit.Tests.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <ImplicitUsings>enable</ImplicitUsings>
         <Nullable>enable</Nullable>
         <IsPackable>false</IsPackable>

--- a/tools/Sandbox/Sandbox.csproj
+++ b/tools/Sandbox/Sandbox.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net9.0</TargetFramework>
+        <TargetFrameworks>net9.0;net10.0</TargetFrameworks>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
     </PropertyGroup>


### PR DESCRIPTION
## Summary
- multi-target PostKit, tests, and sandbox projects for .NET 9.0 and 10.0, bump the library version to 10.0.0-preview.1, and upgrade LightResults to 10.0.0
- update the GitHub workflows so they install both the .NET 9 and .NET 10 SDKs and exercise all target frameworks when testing and publishing

## Testing
- dotnet test --configuration Release
- dotnet test tests/PostKit.Tests/PostKit.Tests.csproj --configuration Release --framework net10.0 -v normal

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6917d3da439c8328bb31fc2b8ac0426e)