### PR TITLE
Add batch email sending support

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,37 @@ var email = Email.CreateBuilder()
 await _postKitClient.SendEmailAsync(email);
 ```
 
+#### Batch Sending
+
+```csharp
+var welcomeEmail = Email.CreateBuilder()
+    .From("noreply@yourapp.com")
+    .To("user1@example.com")
+    .WithSubject("Welcome!")
+    .WithTextBody("Thanks for signing up")
+    .Build();
+
+var reminderEmail = Email.CreateBuilder()
+    .From("noreply@yourapp.com")
+    .To("user2@example.com")
+    .WithSubject("Complete Your Profile")
+    .WithTextBody("Finish setting up your account")
+    .Build();
+
+var batchResult = await _postKitClient.SendEmailBatchAsync(new[] { welcomeEmail, reminderEmail });
+
+if (!batchResult.IsSuccessful)
+{
+    foreach (var result in batchResult.Results.Where(result => !result.IsSuccessful))
+    {
+        // Inspect result.Email and result.Message to handle the failure.
+    }
+}
+```
+
+> **Note:** Postmark accepts up to 500 emails per batch, and every email in the batch must either use a template or none may us
+e one.
+
 #### Advanced Features
 
 ```csharp

--- a/src/PostKit/IPostKitClient.cs
+++ b/src/PostKit/IPostKitClient.cs
@@ -11,4 +11,12 @@ public interface IPostKitClient
     /// <param name="cancellationToken">A token used to cancel the operation.</param>
     /// <returns>A result containing the send response or error information.</returns>
     Task<Result<SendEmailResponse>> SendEmailAsync(Email email, CancellationToken cancellationToken = default);
+
+    /// <summary>Sends a batch of email messages asynchronously.</summary>
+    /// <param name="emails">The collection of emails to send.</param>
+    /// <param name="cancellationToken">A token used to cancel the operation.</param>
+    /// <returns>A result containing the batch send response or error information.</returns>
+    Task<Result<SendEmailBatchResponse>> SendEmailBatchAsync(
+        IReadOnlyCollection<Email> emails,
+        CancellationToken cancellationToken = default);
 }

--- a/src/PostKit/PostKitClient.cs
+++ b/src/PostKit/PostKitClient.cs
@@ -1,4 +1,6 @@
-﻿using LightResults;
+﻿﻿using System.Collections.Generic;
+using System.Linq;
+using LightResults;
 using Microsoft.Extensions.Logging;
 using MimeKit;
 using PostKit.Common;
@@ -10,6 +12,8 @@ namespace PostKit;
 
 internal sealed partial class PostKitClient(IPostmarkClient postmark, ILogger<PostKitClient> logger) : IPostKitClient
 {
+    private const int MaxBatchSize = 500;
+
     public async Task<Result<SendEmailResponse>> SendEmailAsync(Email email, CancellationToken cancellationToken = default)
     {
         var request = email.ToEmailRequest();
@@ -48,6 +52,107 @@ internal sealed partial class PostKitClient(IPostmarkClient postmark, ILogger<Po
         return Result.Success(sendEmailResponse);
     }
 
+    public async Task<Result<SendEmailBatchResponse>> SendEmailBatchAsync(
+        IReadOnlyCollection<Email> emails,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(emails);
+
+        if (emails.Count == 0)
+            return Result.Failure<SendEmailBatchResponse>("At least one email must be provided to send a batch.");
+
+        if (emails.Count > MaxBatchSize)
+        {
+            return Result.Failure<SendEmailBatchResponse>(
+                $"Postmark only accepts {MaxBatchSize} emails per batch request.");
+        }
+
+        var emailList = emails.ToList();
+        var requests = new List<EmailRequest>(emailList.Count);
+        var templateCount = 0;
+
+        foreach (var email in emailList)
+        {
+            ArgumentNullException.ThrowIfNull(email);
+
+            if (email.TemplateId.HasValue || email.TemplateAlias is not null)
+                templateCount++;
+
+            requests.Add(email.ToEmailRequest());
+        }
+
+        if (templateCount > 0 && templateCount < emailList.Count)
+        {
+            return Result.Failure<SendEmailBatchResponse>(
+                "Each email in a batch must either use a template or none may use a template.");
+        }
+
+        var endpoint = templateCount > 0 ? "/email/batchWithTemplates" : "/email/batch";
+
+        Result<List<EmailResponse>> response;
+        try
+        {
+            response = await postmark.SendAsync<List<EmailRequest>, List<EmailResponse>>(endpoint, requests, cancellationToken);
+        }
+        catch (Exception ex)
+        {
+            LogBatchException(ex);
+            return Result.Failure<SendEmailBatchResponse>(ex);
+        }
+
+        if (response.IsFailure(out var error, out var emailResponses))
+        {
+            LogBatchError(error.Message, error);
+            return Result.Failure<SendEmailBatchResponse>(error);
+        }
+
+        if (emailResponses.Count != emailList.Count)
+        {
+            return Result.Failure<SendEmailBatchResponse>(
+                "Postmark returned an unexpected number of results for the batch request.");
+        }
+
+        var batchResults = new List<SendEmailBatchResult>(emailResponses.Count);
+
+        for (var index = 0; index < emailResponses.Count; index++)
+        {
+            var email = emailList[index];
+            var emailResponse = emailResponses[index];
+
+            SendEmailResponse? sendEmailResponse = null;
+            if (emailResponse.MessageId is not null)
+                sendEmailResponse = new SendEmailResponse(emailResponse.MessageId);
+
+            var batchResult = new SendEmailBatchResult(
+                email,
+                emailResponse.Message,
+                emailResponse.ErrorCode,
+                emailResponse.To,
+                emailResponse.SubmittedAt,
+                sendEmailResponse);
+
+            batchResults.Add(batchResult);
+
+            if (batchResult.IsSuccessful)
+            {
+                if (email.To is not null)
+                    LogEmailSent(email.To, emailResponse);
+                else if (email.Cc is not null)
+                    LogEmailSent(email.Cc, emailResponse);
+                else if (email.Bcc is not null)
+                    LogEmailSent(email.Bcc, emailResponse);
+            }
+            else
+            {
+                LogBatchEmailFailure(index, emailResponse.Message, emailResponse.ErrorCode);
+            }
+        }
+
+        var sendEmailBatchResponse = new SendEmailBatchResponse(batchResults.AsReadOnly());
+
+        return Result.Success(sendEmailBatchResponse);
+    }
+
     [LoggerMessage(LogLevel.Error, "An exception occurred while attempting to send the email.")]
     private partial void LogException(Exception ex);
 
@@ -56,4 +161,13 @@ internal sealed partial class PostKitClient(IPostmarkClient postmark, ILogger<Po
 
     [LoggerMessage(LogLevel.Information, "Sent email to {To}.")]
     private partial void LogEmailSent(IReadOnlyCollection<MailboxAddress> to, [LogProperties] EmailResponse emailResponse);
+
+    [LoggerMessage(LogLevel.Error, "An exception occurred while attempting to send the batch of emails.")]
+    private partial void LogBatchException(Exception ex);
+
+    [LoggerMessage(LogLevel.Error, "Failed to send the batch of emails. {Message}")]
+    private partial void LogBatchError(string message, [LogProperties] IError error);
+
+    [LoggerMessage(LogLevel.Warning, "Postmark rejected email {Index} in the batch. {Message} (ErrorCode: {ErrorCode})")]
+    private partial void LogBatchEmailFailure(int index, string message, int errorCode);
 }

--- a/src/PostKit/Postmark/PostmarkClient.cs
+++ b/src/PostKit/Postmark/PostmarkClient.cs
@@ -1,4 +1,5 @@
 ﻿#if DEBUG
+using Microsoft.Extensions.Logging;
 using System.Net.Mime;
 using System.Text;
 #else

--- a/src/PostKit/Responses/SendEmailBatchResponse.cs
+++ b/src/PostKit/Responses/SendEmailBatchResponse.cs
@@ -1,0 +1,68 @@
+using System.Collections.ObjectModel;
+using System.Linq;
+using JetBrains.Annotations;
+using global::PostKit;
+
+namespace PostKit.Responses;
+
+/// <summary>Represents the response returned after Postmark processes a batch of emails.</summary>
+public sealed record SendEmailBatchResponse
+{
+    /// <summary>Gets the individual results for each email in the batch.</summary>
+    public IReadOnlyList<SendEmailBatchResult> Results { [UsedImplicitly] get; }
+
+    /// <summary>Gets a value indicating whether every email in the batch was accepted for delivery.</summary>
+    public bool IsSuccessful { [UsedImplicitly] get; }
+
+    internal SendEmailBatchResponse(IReadOnlyList<SendEmailBatchResult> results)
+    {
+        Results = results switch
+        {
+            ReadOnlyCollection<SendEmailBatchResult> collection => collection,
+            _ => new ReadOnlyCollection<SendEmailBatchResult>(results.ToList()),
+        };
+
+        IsSuccessful = Results.All(static result => result.IsSuccessful);
+    }
+}
+
+/// <summary>Represents the result of attempting to send a single email within a batch.</summary>
+public sealed record SendEmailBatchResult
+{
+    /// <summary>Gets the email that was sent.</summary>
+    public Email Email { [UsedImplicitly] get; }
+
+    /// <summary>Gets the Postmark message returned for the email.</summary>
+    public string Message { [UsedImplicitly] get; }
+
+    /// <summary>Gets the Postmark error code returned for the email.</summary>
+    public int ErrorCode { [UsedImplicitly] get; }
+
+    /// <summary>Gets the recipient string returned by Postmark.</summary>
+    public string? Recipient { [UsedImplicitly] get; }
+
+    /// <summary>Gets the time Postmark accepted the email.</summary>
+    public DateTimeOffset? SubmittedAt { [UsedImplicitly] get; }
+
+    /// <summary>Gets the successful send response, when available.</summary>
+    public SendEmailResponse? Response { [UsedImplicitly] get; }
+
+    /// <summary>Gets a value indicating whether the email was accepted by Postmark.</summary>
+    public bool IsSuccessful => ErrorCode == 0 && Response is not null;
+
+    internal SendEmailBatchResult(
+        Email email,
+        string message,
+        int errorCode,
+        string? recipient,
+        DateTimeOffset? submittedAt,
+        SendEmailResponse? response)
+    {
+        Email = email;
+        Message = message;
+        ErrorCode = errorCode;
+        Recipient = recipient;
+        SubmittedAt = submittedAt;
+        Response = response;
+    }
+}


### PR DESCRIPTION
## Summary
- add a batch email sending API and supporting response types
- update PostKitClient to enforce Postmark batch rules and log individual results
- document the new SendEmailBatchAsync workflow in the README

## Testing
- dotnet test

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691a144204d08328a70eb2c8a78da815)