### PR TITLE
Fixed outbound message details body nullability.

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,6 +500,7 @@ if (messagesResult.IsSuccess(out var page))
 ```
 
 Outbound message date filters accept `DateTimeOffset` values and are converted to Postmark's US Eastern time before the request is made. Postmark currently supports one metadata filter per outbound message search.
+Outbound message details expose nullable `TextBody` and `HtmlBody` properties because Postmark returns `null` for content variants that were not present on the sent message.
 
 ### Suppressions
 

--- a/src/PostKit/Messages/OutboundMessageDetails.cs
+++ b/src/PostKit/Messages/OutboundMessageDetails.cs
@@ -6,11 +6,11 @@ namespace PostKit.Messages;
 /// <summary>Represents a single outbound message returned from the Postmark outbound message details endpoint.</summary>
 public sealed record OutboundMessageDetails : OutboundMessage
 {
-    /// <summary>Gets the text body of the message.</summary>
-    public string TextBody { [UsedImplicitly] get; }
+    /// <summary>Gets the text body of the message, when the message has one.</summary>
+    public string? TextBody { [UsedImplicitly] get; }
 
-    /// <summary>Gets the HTML body of the message.</summary>
-    public string HtmlBody { [UsedImplicitly] get; }
+    /// <summary>Gets the HTML body of the message, when the message has one.</summary>
+    public string? HtmlBody { [UsedImplicitly] get; }
 
     /// <summary>Gets the raw source of the message.</summary>
     public string Body { [UsedImplicitly] get; }
@@ -35,8 +35,8 @@ public sealed record OutboundMessageDetails : OutboundMessage
         LinkTracking trackLinks,
         IReadOnlyDictionary<string, string> metadata,
         bool sandboxed,
-        string textBody,
-        string htmlBody,
+        string? textBody,
+        string? htmlBody,
         string body,
         IReadOnlyCollection<OutboundMessageEvent> messageEvents
     )

--- a/src/PostKit/PostKit.csproj
+++ b/src/PostKit/PostKit.csproj
@@ -28,9 +28,9 @@
     <!-- Output -->
     <PropertyGroup>
         <AssemblyName>PostKit</AssemblyName>
-        <Version>10.1.3</Version>
-        <AssemblyVersion>10.1.3.0</AssemblyVersion>
-        <FileVersion>10.1.3.0</FileVersion>
+        <Version>10.1.4</Version>
+        <AssemblyVersion>10.1.4.0</AssemblyVersion>
+        <FileVersion>10.1.4.0</FileVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <Optimize>true</Optimize>
         <!--<IsAotCompatible>true</IsAotCompatible>-->

--- a/src/PostKit/PostKitClient.Messages.cs
+++ b/src/PostKit/PostKitClient.Messages.cs
@@ -323,12 +323,6 @@ internal sealed partial class PostKitClient
         if (mappedCore.IsFailure(out var error, out var outboundMessageCore))
             return Result.Failure<OutboundMessageDetails>(error);
 
-        if (response.TextBody is null)
-            return Result.Failure<OutboundMessageDetails>("TextBody was not returned from the Postmark Messages API.");
-
-        if (response.HtmlBody is null)
-            return Result.Failure<OutboundMessageDetails>("HtmlBody was not returned from the Postmark Messages API.");
-
         if (response.Body is null)
             return Result.Failure<OutboundMessageDetails>("Body was not returned from the Postmark Messages API.");
 

--- a/tests/PostKit.Tests/PostKitClientMessageResponseTests.cs
+++ b/tests/PostKit.Tests/PostKitClientMessageResponseTests.cs
@@ -259,7 +259,7 @@ public class PostKitClientMessageResponseTests
     }
 
     [Fact]
-    public async Task GetOutboundMessageDetailsAsync_WhenTextBodyIsMissing_ReturnsHelpfulFailure()
+    public async Task GetOutboundMessageDetailsAsync_WhenTextBodyIsNull_MapsNullableTextBody()
     {
         var messageId = Guid.Parse("07311c54-0687-4ab9-b034-b54b5bad88ba");
         const string endpoint = "/messages/outbound/07311c54-0687-4ab9-b034-b54b5bad88ba/details";
@@ -269,8 +269,40 @@ public class PostKitClientMessageResponseTests
 
         var result = await client.GetOutboundMessageDetailsAsync(messageId, CancellationToken.None);
 
+        Assert.True(result.IsSuccess(out var response), result.ToString());
+        Assert.Null(response.TextBody);
+        Assert.Equal("<p>Thank you for your order...</p>", response.HtmlBody);
+    }
+
+    [Fact]
+    public async Task GetOutboundMessageDetailsAsync_WhenHtmlBodyIsNull_MapsNullableHtmlBody()
+    {
+        var messageId = Guid.Parse("07311c54-0687-4ab9-b034-b54b5bad88ba");
+        const string endpoint = "/messages/outbound/07311c54-0687-4ab9-b034-b54b5bad88ba/details";
+        var responseJson = SuccessfulDetailsResponseJson.Replace("\"HtmlBody\": \"<p>Thank you for your order...</p>\"", "\"HtmlBody\": null", StringComparison.Ordinal);
+        var postmark = new RecordingPostmarkClient(new Dictionary<string, string> { [endpoint] = responseJson });
+        var client = new PostKitClient(postmark, new TestLogger());
+
+        var result = await client.GetOutboundMessageDetailsAsync(messageId, CancellationToken.None);
+
+        Assert.True(result.IsSuccess(out var response), result.ToString());
+        Assert.Equal("Thank you for your order...", response.TextBody);
+        Assert.Null(response.HtmlBody);
+    }
+
+    [Fact]
+    public async Task GetOutboundMessageDetailsAsync_WhenBodyIsMissing_ReturnsHelpfulFailure()
+    {
+        var messageId = Guid.Parse("07311c54-0687-4ab9-b034-b54b5bad88ba");
+        const string endpoint = "/messages/outbound/07311c54-0687-4ab9-b034-b54b5bad88ba/details";
+        var responseJson = SuccessfulDetailsResponseJson.Replace("\"Body\": \"SMTP dump data\"", "\"Body\": null", StringComparison.Ordinal);
+        var postmark = new RecordingPostmarkClient(new Dictionary<string, string> { [endpoint] = responseJson });
+        var client = new PostKitClient(postmark, new TestLogger());
+
+        var result = await client.GetOutboundMessageDetailsAsync(messageId, CancellationToken.None);
+
         Assert.True(result.IsFailure(out var error, out var _), result.ToString());
-        Assert.Equal("TextBody was not returned from the Postmark Messages API.", error.Message);
+        Assert.Equal("Body was not returned from the Postmark Messages API.", error.Message);
     }
 
     [Fact]


### PR DESCRIPTION
- Fixed outbound message details mapping so Postmark `TextBody` and `HtmlBody` nulls are treated as valid absent content variants.
- Kept raw `Body` validation in place for malformed details responses.
- Updated package version metadata to `10.1.4` / `10.1.4.0`.
- Validated with `dotnet test tests\PostKit.Tests\PostKit.Tests.csproj --framework net10.0`.