### PR TITLE
Added Postmark API rate limit handling.

### DIFF
--- a/src/PostKit/PostKit.csproj
+++ b/src/PostKit/PostKit.csproj
@@ -28,9 +28,9 @@
     <!-- Output -->
     <PropertyGroup>
         <AssemblyName>PostKit</AssemblyName>
-        <Version>10.1.4</Version>
-        <AssemblyVersion>10.1.4.0</AssemblyVersion>
-        <FileVersion>10.1.4.0</FileVersion>
+        <Version>10.1.5</Version>
+        <AssemblyVersion>10.1.5.0</AssemblyVersion>
+        <FileVersion>10.1.5.0</FileVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <Optimize>true</Optimize>
         <!--<IsAotCompatible>true</IsAotCompatible>-->

--- a/src/PostKit/PostKitExtensions.cs
+++ b/src/PostKit/PostKitExtensions.cs
@@ -201,6 +201,7 @@ public static class PostKitExtensions
     {
         services.AddHttpClient("Postmark");
         services.TryAddSingleton<IPostmarkClientFactory, PostmarkClientFactory>();
+        services.TryAddSingleton<PostmarkRateLimiter>();
     }
 
     private static OptionsBuilder<PostKitOptions> AddValidatedOptions(IServiceCollection services, string optionsName, bool validateConfigurationSectionFromServices)

--- a/src/PostKit/Postmark/PostmarkClient.cs
+++ b/src/PostKit/Postmark/PostmarkClient.cs
@@ -16,16 +16,20 @@ namespace PostKit.Postmark;
 [UsedImplicitly]
 internal sealed partial class PostmarkClient : IPostmarkClient
 {
+    private static readonly TimeSpan InitialTooManyRequestsRetryDelay = TimeSpan.FromMilliseconds(100);
+    private static readonly TimeSpan FinalTooManyRequestsRetryDelay = TimeSpan.FromMilliseconds(1600);
     private static readonly string Version = typeof(PostmarkClient).Assembly.GetName()
         .Version!.ToString(2);
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<PostmarkClient> _logger;
+    private readonly PostmarkRateLimiter _rateLimiter;
 
-    public PostmarkClient(HttpClient httpClient, IOptions<PostKitOptions> options, ILogger<PostmarkClient> logger)
+    public PostmarkClient(HttpClient httpClient, IOptions<PostKitOptions> options, ILogger<PostmarkClient> logger, PostmarkRateLimiter? rateLimiter = null)
     {
         _httpClient = httpClient;
         _logger = logger;
+        _rateLimiter = rateLimiter ?? new PostmarkRateLimiter();
 
         if (string.IsNullOrWhiteSpace(options.Value.ServerApiToken))
             throw new InvalidOperationException("The server API token has not been set.");
@@ -39,25 +43,66 @@ internal sealed partial class PostmarkClient : IPostmarkClient
     public async Task<Result<TResponse>> PostAsync<TRequest, TResponse>(string endpoint, TRequest body, CancellationToken cancellationToken = default)
     {
         var jsonToSend = JsonSerializer.Serialize(body, PostmarkConfiguration.JsonSerializerOptions);
-        LogApiRequest(endpoint, Encoding.UTF8.GetByteCount(jsonToSend));
-        using var contentToSend = new StringContent(jsonToSend, Encoding.UTF8, MediaTypeNames.Application.Json);
-        using var responseMessage = await _httpClient.PostAsync(endpoint, contentToSend, cancellationToken);
+        var sizeInBytes = Encoding.UTF8.GetByteCount(jsonToSend);
+        using var responseMessage = await SendAsync(endpoint,
+            () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Post, endpoint) { Content = new StringContent(jsonToSend, Encoding.UTF8, MediaTypeNames.Application.Json) };
+                return request;
+            },
+            sizeInBytes,
+            cancellationToken
+        );
         return await GetResponse<TResponse>(endpoint, responseMessage, cancellationToken);
     }
 
     public async Task<Result<TResponse>> GetAsync<TResponse>(string endpoint, CancellationToken cancellationToken = default)
     {
-        using var responseMessage = await _httpClient.GetAsync(endpoint, cancellationToken);
+        using var responseMessage = await SendAsync(endpoint, () => new HttpRequestMessage(HttpMethod.Get, endpoint), null, cancellationToken);
         return await GetResponse<TResponse>(endpoint, responseMessage, cancellationToken);
     }
 
     public async Task<Result<TResponse>> PutAsync<TResponse>(string endpoint, CancellationToken cancellationToken = default)
     {
         const string emptyJsonObject = "{}";
-        LogApiRequest(endpoint, Encoding.UTF8.GetByteCount(emptyJsonObject));
-        using var contentToSend = new StringContent(emptyJsonObject, Encoding.UTF8, MediaTypeNames.Application.Json);
-        using var responseMessage = await _httpClient.PutAsync(endpoint, contentToSend, cancellationToken);
+        using var responseMessage = await SendAsync(endpoint,
+            () =>
+            {
+                var request = new HttpRequestMessage(HttpMethod.Put, endpoint) { Content = new StringContent(emptyJsonObject, Encoding.UTF8, MediaTypeNames.Application.Json) };
+                return request;
+            },
+            Encoding.UTF8.GetByteCount(emptyJsonObject),
+            cancellationToken
+        );
         return await GetResponse<TResponse>(endpoint, responseMessage, cancellationToken);
+    }
+
+    private async Task<HttpResponseMessage> SendAsync(string endpoint, Func<HttpRequestMessage> createRequest, int? requestSizeInBytes, CancellationToken cancellationToken)
+    {
+        var nextTooManyRequestsRetryDelay = InitialTooManyRequestsRetryDelay;
+        TimeSpan? previousTooManyRequestsRetryDelay = null;
+
+        while (true)
+        {
+            var lease = await _rateLimiter.WaitForAvailabilityAsync(endpoint, cancellationToken);
+            if (requestSizeInBytes.HasValue)
+                LogApiRequest(endpoint, requestSizeInBytes.Value);
+
+            using var request = createRequest();
+            var responseMessage = await _httpClient.SendAsync(request, cancellationToken);
+            _rateLimiter.ObserveResponse(endpoint, responseMessage.Headers, lease);
+
+            if (responseMessage.StatusCode != HttpStatusCode.TooManyRequests)
+                return responseMessage;
+
+            if (previousTooManyRequestsRetryDelay.HasValue && previousTooManyRequestsRetryDelay.Value >= FinalTooManyRequestsRetryDelay)
+                return responseMessage;
+
+            responseMessage.Dispose();
+            await _rateLimiter.DelayAsync(nextTooManyRequestsRetryDelay, cancellationToken);
+            previousTooManyRequestsRetryDelay = nextTooManyRequestsRetryDelay;
+            nextTooManyRequestsRetryDelay = TimeSpan.FromMilliseconds(Math.Min(nextTooManyRequestsRetryDelay.TotalMilliseconds * 2, FinalTooManyRequestsRetryDelay.TotalMilliseconds));
+        }
     }
 
     private async Task<Result<TResponse>> GetResponse<TResponse>(string endpoint, HttpResponseMessage responseMessage, CancellationToken cancellationToken)

--- a/src/PostKit/Postmark/PostmarkClientFactory.cs
+++ b/src/PostKit/Postmark/PostmarkClientFactory.cs
@@ -6,12 +6,12 @@ using PostKit.Configuration;
 namespace PostKit.Postmark;
 
 [UsedImplicitly]
-internal sealed class PostmarkClientFactory(IHttpClientFactory httpClientFactory, IOptions<PostKitOptions> defaultOptions, IOptionsMonitor<PostKitOptions> namedOptions, ILogger<PostmarkClient> logger) : IPostmarkClientFactory
+internal sealed class PostmarkClientFactory(IHttpClientFactory httpClientFactory, IOptions<PostKitOptions> defaultOptions, IOptionsMonitor<PostKitOptions> namedOptions, ILogger<PostmarkClient> logger, PostmarkRateLimiter rateLimiter) : IPostmarkClientFactory
 {
     public PostmarkClient Create(string? key = null)
     {
         var httpClient = httpClientFactory.CreateClient("Postmark");
         var postKitOptions = key is null ? defaultOptions.Value : namedOptions.Get(key);
-        return new PostmarkClient(httpClient, Options.Create(postKitOptions), logger);
+        return new PostmarkClient(httpClient, Options.Create(postKitOptions), logger, rateLimiter);
     }
 }

--- a/src/PostKit/Postmark/PostmarkRateLimiter.cs
+++ b/src/PostKit/Postmark/PostmarkRateLimiter.cs
@@ -1,0 +1,158 @@
+using System.Collections.Concurrent;
+using System.Diagnostics;
+using System.Net.Http.Headers;
+
+namespace PostKit.Postmark;
+
+internal sealed class PostmarkRateLimiter(Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
+{
+    private static readonly TimeSpan RateLimitWindow = TimeSpan.FromSeconds(1);
+    private readonly ConcurrentDictionary<string, RateLimitBucket> _buckets = new(StringComparer.Ordinal);
+    private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync = delayAsync ?? Task.Delay;
+
+    public async Task<PostmarkRateLimitLease> WaitForAvailabilityAsync(string endpoint, CancellationToken cancellationToken)
+    {
+        var bucketKey = GetBucketKey(endpoint);
+        if (!_buckets.TryGetValue(bucketKey, out var bucket))
+            return new PostmarkRateLimitLease(bucketKey, false);
+
+        var delay = bucket.RecordRequestAndGetDelay();
+        if (delay > TimeSpan.Zero)
+            await _delayAsync(delay, cancellationToken);
+
+        return new PostmarkRateLimitLease(bucketKey, true);
+    }
+
+    public void ObserveResponse(string endpoint, HttpResponseHeaders headers, PostmarkRateLimitLease lease)
+    {
+        if (!TryGetRateLimit(headers, out var limit))
+            return;
+
+        var bucketKey = string.IsNullOrEmpty(lease.BucketKey) ? GetBucketKey(endpoint) : lease.BucketKey;
+        var bucket = _buckets.GetOrAdd(bucketKey, static _ => new RateLimitBucket());
+        bucket.SetLimit(limit);
+
+        if (!lease.Recorded)
+            bucket.RecordObservedRequest();
+    }
+
+    public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
+    {
+        return _delayAsync(delay, cancellationToken);
+    }
+
+    private static bool TryGetRateLimit(HttpResponseHeaders headers, out int limit)
+    {
+        limit = 0;
+        return TryGetPositiveIntHeader(headers, "RateLimit-Limit", out limit) || TryGetPositiveIntHeader(headers, "X-RateLimit-Limit-Second", out limit);
+    }
+
+    private static bool TryGetPositiveIntHeader(HttpResponseHeaders headers, string name, out int value)
+    {
+        value = 0;
+        if (!headers.TryGetValues(name, out var values))
+            return false;
+
+        foreach (var headerValue in values)
+        {
+            if (int.TryParse(headerValue, out value) && value > 0)
+                return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static string GetBucketKey(string endpoint)
+    {
+        var queryIndex = endpoint.IndexOf('?', StringComparison.Ordinal);
+        var path = queryIndex < 0 ? endpoint : endpoint[..queryIndex];
+
+        if (path.StartsWith("/messages/outbound", StringComparison.OrdinalIgnoreCase))
+            return "messages/outbound";
+
+        if (path.StartsWith("/message-streams/", StringComparison.OrdinalIgnoreCase) && path.Contains("/suppressions", StringComparison.OrdinalIgnoreCase))
+            return "message-streams/suppressions";
+
+        if (path.StartsWith("/email", StringComparison.OrdinalIgnoreCase))
+            return "email";
+
+        return path.ToLowerInvariant();
+    }
+
+    private sealed class RateLimitBucket
+    {
+        private readonly object _gate = new();
+        private readonly Queue<long> _requestTimestamps = new();
+        private int? _limit;
+
+        public void SetLimit(int limit)
+        {
+            lock (_gate)
+            {
+                _limit = limit;
+                PruneOldRequests(Stopwatch.GetTimestamp());
+            }
+        }
+
+        public void RecordObservedRequest()
+        {
+            lock (_gate)
+            {
+                var now = Stopwatch.GetTimestamp();
+                PruneOldRequests(now);
+                _requestTimestamps.Enqueue(now);
+            }
+        }
+
+        public TimeSpan RecordRequestAndGetDelay()
+        {
+            lock (_gate)
+            {
+                var now = Stopwatch.GetTimestamp();
+                PruneOldRequests(now);
+
+                if (_limit is null || _requestTimestamps.Count == 0)
+                {
+                    _requestTimestamps.Enqueue(now);
+                    return TimeSpan.Zero;
+                }
+
+                var targetRequestsPerWindow = Math.Max(1, _limit.Value - 1);
+                var oldest = _requestTimestamps.Peek();
+                var actualElapsedMilliseconds = GetElapsedMilliseconds(oldest, now);
+                var idealElapsedMilliseconds = (_requestTimestamps.Count + 1) * RateLimitWindow.TotalMilliseconds / targetRequestsPerWindow;
+                var delayMilliseconds = idealElapsedMilliseconds - actualElapsedMilliseconds;
+
+                if (delayMilliseconds <= 0)
+                {
+                    _requestTimestamps.Enqueue(now);
+                    return TimeSpan.Zero;
+                }
+
+                var roundedDelayMilliseconds = Math.Max(1, (int)Math.Ceiling(delayMilliseconds));
+                var delay = TimeSpan.FromMilliseconds(roundedDelayMilliseconds);
+                _requestTimestamps.Enqueue(AddDelay(now, delay));
+                return delay;
+            }
+        }
+
+        private void PruneOldRequests(long now)
+        {
+            while (_requestTimestamps.TryPeek(out var timestamp) && GetElapsedMilliseconds(timestamp, now) >= RateLimitWindow.TotalMilliseconds)
+                _requestTimestamps.Dequeue();
+        }
+
+        private static double GetElapsedMilliseconds(long startTimestamp, long endTimestamp)
+        {
+            return (endTimestamp - startTimestamp) * 1000.0 / Stopwatch.Frequency;
+        }
+
+        private static long AddDelay(long timestamp, TimeSpan delay)
+        {
+            return timestamp + (long)Math.Ceiling(delay.TotalSeconds * Stopwatch.Frequency);
+        }
+    }
+}
+
+internal readonly record struct PostmarkRateLimitLease(string BucketKey, bool Recorded);

--- a/tests/PostKit.Tests/PostmarkClientErrorHandlingTests.cs
+++ b/tests/PostKit.Tests/PostmarkClientErrorHandlingTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Net.Mime;
 using System.Text;
 using System.Text.Json.Nodes;
+using System.Globalization;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using PostKit.Configuration;
@@ -130,10 +131,135 @@ public class PostmarkClientErrorHandlingTests
         Assert.Equal("{}", handler.LastContentBody);
     }
 
+    [Fact]
+    public async Task GetAsync_WithRateLimitHeaders_DelaysSuccessiveCallsInLearnedBucket()
+    {
+        var delays = new List<TimeSpan>();
+        using var handler = new SequenceHttpMessageHandler(
+            CreateRateLimitedResponse(HttpStatusCode.OK, 10),
+            CreateRateLimitedResponse(HttpStatusCode.OK, 10)
+        );
+        using var httpClient = new HttpClient(handler);
+        var rateLimiter = new PostmarkRateLimiter((delay, _) =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            }
+        );
+        var client = new PostmarkClient(httpClient, Options.Create(new PostKitOptions { ServerApiToken = "token" }), new TestLogger<PostmarkClient>(), rateLimiter);
+
+        var firstResult = await client.GetAsync<PostmarkResponse>("/messages/outbound?count=1", CancellationToken.None);
+        var secondResult = await client.GetAsync<PostmarkResponse>("/messages/outbound/07311c54-0687-4ab9-b034-b54b5bad88ba/details", CancellationToken.None);
+
+        Assert.True(firstResult.IsSuccess(out _), firstResult.ToString());
+        Assert.True(secondResult.IsSuccess(out _), secondResult.ToString());
+        var delay = Assert.Single(delays);
+        Assert.True(delay >= TimeSpan.FromMilliseconds(1), $"Expected at least a 1 ms delay, received {delay.TotalMilliseconds} ms.");
+    }
+
+    [Fact]
+    public async Task GetAsync_WithTooManyRequests_RetriesWithExponentialBackoff()
+    {
+        var delays = new List<TimeSpan>();
+        using var handler = new SequenceHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{"ErrorCode":0,"Message":"OK"}""", Encoding.UTF8, MediaTypeNames.Application.Json) }
+        );
+        using var httpClient = new HttpClient(handler);
+        var rateLimiter = new PostmarkRateLimiter((delay, _) =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            }
+        );
+        var client = new PostmarkClient(httpClient, Options.Create(new PostKitOptions { ServerApiToken = "token" }), new TestLogger<PostmarkClient>(), rateLimiter);
+
+        var result = await client.GetAsync<PostmarkResponse>("/bounces?count=1&offset=0", CancellationToken.None);
+
+        Assert.True(result.IsSuccess(out _), result.ToString());
+        Assert.Equal(3, handler.RequestCount);
+        Assert.Equal([TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(200)], delays);
+    }
+
+    [Fact]
+    public async Task GetAsync_WithRepeatedTooManyRequests_ReturnsFailureAfterRetryAtFinalDelay()
+    {
+        var delays = new List<TimeSpan>();
+        using var handler = new SequenceHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests)
+        );
+        using var httpClient = new HttpClient(handler);
+        var rateLimiter = new PostmarkRateLimiter((delay, _) =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            }
+        );
+        var client = new PostmarkClient(httpClient, Options.Create(new PostKitOptions { ServerApiToken = "token" }), new TestLogger<PostmarkClient>(), rateLimiter);
+
+        var result = await client.GetAsync<PostmarkResponse>("/bounces?count=1&offset=0", CancellationToken.None);
+
+        Assert.True(result.IsFailure(out var error, out var _), result.ToString());
+        var httpError = Assert.IsType<HttpError>(error);
+        Assert.Equal(HttpStatusCode.TooManyRequests, httpError.StatusCode);
+        Assert.Equal(6, handler.RequestCount);
+        Assert.Equal(
+            [
+                TimeSpan.FromMilliseconds(100),
+                TimeSpan.FromMilliseconds(200),
+                TimeSpan.FromMilliseconds(400),
+                TimeSpan.FromMilliseconds(800),
+                TimeSpan.FromMilliseconds(1600),
+            ],
+            delays
+        );
+    }
+
     private sealed class StubHttpMessageHandler(HttpResponseMessage responseMessage) : HttpMessageHandler
     {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            return Task.FromResult(responseMessage);
+        }
+    }
+
+    private static HttpResponseMessage CreateRateLimitedResponse(HttpStatusCode statusCode, int rateLimit)
+    {
+        var response = new HttpResponseMessage(statusCode) { Content = new StringContent("""{"ErrorCode":0,"Message":"OK"}""", Encoding.UTF8, MediaTypeNames.Application.Json) };
+        response.Headers.Add("RateLimit-Limit", rateLimit.ToString(CultureInfo.InvariantCulture));
+        response.Headers.Add("RateLimit-Remaining", (rateLimit - 1).ToString(CultureInfo.InvariantCulture));
+        response.Headers.Add("RateLimit-Reset", "1");
+        response.Headers.Add("X-RateLimit-Limit-Second", rateLimit.ToString(CultureInfo.InvariantCulture));
+        response.Headers.Add("X-RateLimit-Remaining-Second", (rateLimit - 1).ToString(CultureInfo.InvariantCulture));
+        return response;
+    }
+
+    private sealed class SequenceHttpMessageHandler(params HttpResponseMessage[] responseMessages) : HttpMessageHandler, IDisposable
+    {
+        private readonly Queue<HttpResponseMessage> _responseMessages = new(responseMessages);
+
+        public int RequestCount { get; private set; }
+
+        public new void Dispose()
+        {
+            while (_responseMessages.TryDequeue(out var responseMessage))
+                responseMessage.Dispose();
+
+            base.Dispose();
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            RequestCount++;
+            if (!_responseMessages.TryDequeue(out var responseMessage))
+                throw new InvalidOperationException("No response message was queued for this request.");
+
             return Task.FromResult(responseMessage);
         }
     }


### PR DESCRIPTION
- Added shared Postmark API rate-limit tracking from `RateLimit-Limit` / `X-RateLimit-Limit-Second` response headers.
- Added adaptive pacing for endpoint groups that publish per-second limits so repeated calls stay just below the observed limit.
- Added exponential retry handling for `429 Too Many Requests` responses across all Postmark endpoints, from `100ms` up to `1600ms` before returning the final rate-limit failure.
- Updated package version metadata to `10.1.5` / `10.1.5.0`.
- Validated direct sandbox API rate-limit headers for implemented endpoint groups and ran `dotnet test tests\PostKit.Tests\PostKit.Tests.csproj --framework net10.0`.