### PR TITLE
Improved Postmark API rate limit retries.

### DIFF
--- a/src/PostKit/PostKit.csproj
+++ b/src/PostKit/PostKit.csproj
@@ -28,9 +28,9 @@
     <!-- Output -->
     <PropertyGroup>
         <AssemblyName>PostKit</AssemblyName>
-        <Version>10.1.5</Version>
-        <AssemblyVersion>10.1.5.0</AssemblyVersion>
-        <FileVersion>10.1.5.0</FileVersion>
+        <Version>10.1.6</Version>
+        <AssemblyVersion>10.1.6.0</AssemblyVersion>
+        <FileVersion>10.1.6.0</FileVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <Optimize>true</Optimize>
         <!--<IsAotCompatible>true</IsAotCompatible>-->

--- a/src/PostKit/Postmark/PostmarkClient.cs
+++ b/src/PostKit/Postmark/PostmarkClient.cs
@@ -16,20 +16,25 @@ namespace PostKit.Postmark;
 [UsedImplicitly]
 internal sealed partial class PostmarkClient : IPostmarkClient
 {
-    private static readonly TimeSpan InitialTooManyRequestsRetryDelay = TimeSpan.FromMilliseconds(100);
-    private static readonly TimeSpan FinalTooManyRequestsRetryDelay = TimeSpan.FromMilliseconds(1600);
+    private const int TooManyRequestsRetryCount = 6;
+    private const double TooManyRequestsBackoffFactor = 2;
+    private const double TooManyRequestsJitterRatio = 0.2;
+    private static readonly TimeSpan InitialTooManyRequestsRetryDelay = TimeSpan.FromSeconds(1);
+    private static readonly TimeSpan MaximumTooManyRequestsRetryDelay = TimeSpan.FromSeconds(30);
     private static readonly string Version = typeof(PostmarkClient).Assembly.GetName()
         .Version!.ToString(2);
 
     private readonly HttpClient _httpClient;
     private readonly ILogger<PostmarkClient> _logger;
     private readonly PostmarkRateLimiter _rateLimiter;
+    private readonly Func<double> _tooManyRequestsJitterMultiplierProvider;
 
-    public PostmarkClient(HttpClient httpClient, IOptions<PostKitOptions> options, ILogger<PostmarkClient> logger, PostmarkRateLimiter? rateLimiter = null)
+    public PostmarkClient(HttpClient httpClient, IOptions<PostKitOptions> options, ILogger<PostmarkClient> logger, PostmarkRateLimiter? rateLimiter = null, Func<double>? tooManyRequestsJitterMultiplierProvider = null)
     {
         _httpClient = httpClient;
         _logger = logger;
         _rateLimiter = rateLimiter ?? new PostmarkRateLimiter();
+        _tooManyRequestsJitterMultiplierProvider = tooManyRequestsJitterMultiplierProvider ?? GetRandomTooManyRequestsJitterMultiplier;
 
         if (string.IsNullOrWhiteSpace(options.Value.ServerApiToken))
             throw new InvalidOperationException("The server API token has not been set.");
@@ -80,7 +85,7 @@ internal sealed partial class PostmarkClient : IPostmarkClient
     private async Task<HttpResponseMessage> SendAsync(string endpoint, Func<HttpRequestMessage> createRequest, int? requestSizeInBytes, CancellationToken cancellationToken)
     {
         var nextTooManyRequestsRetryDelay = InitialTooManyRequestsRetryDelay;
-        TimeSpan? previousTooManyRequestsRetryDelay = null;
+        var tooManyRequestsRetryCount = 0;
 
         while (true)
         {
@@ -95,14 +100,31 @@ internal sealed partial class PostmarkClient : IPostmarkClient
             if (responseMessage.StatusCode != HttpStatusCode.TooManyRequests)
                 return responseMessage;
 
-            if (previousTooManyRequestsRetryDelay.HasValue && previousTooManyRequestsRetryDelay.Value >= FinalTooManyRequestsRetryDelay)
+            if (tooManyRequestsRetryCount >= TooManyRequestsRetryCount)
                 return responseMessage;
 
             responseMessage.Dispose();
-            await _rateLimiter.DelayAsync(nextTooManyRequestsRetryDelay, cancellationToken);
-            previousTooManyRequestsRetryDelay = nextTooManyRequestsRetryDelay;
-            nextTooManyRequestsRetryDelay = TimeSpan.FromMilliseconds(Math.Min(nextTooManyRequestsRetryDelay.TotalMilliseconds * 2, FinalTooManyRequestsRetryDelay.TotalMilliseconds));
+            _rateLimiter.ObserveTooManyRequests(endpoint, ApplyTooManyRequestsJitter(nextTooManyRequestsRetryDelay));
+            tooManyRequestsRetryCount++;
+            nextTooManyRequestsRetryDelay = GetNextTooManyRequestsRetryDelay(nextTooManyRequestsRetryDelay);
         }
+    }
+
+    private TimeSpan ApplyTooManyRequestsJitter(TimeSpan delay)
+    {
+        var jitterMultiplier = Math.Clamp(_tooManyRequestsJitterMultiplierProvider(), 1 - TooManyRequestsJitterRatio, 1 + TooManyRequestsJitterRatio);
+        var jitteredMilliseconds = Math.Ceiling(delay.TotalMilliseconds * jitterMultiplier);
+        return TimeSpan.FromMilliseconds(Math.Min(jitteredMilliseconds, MaximumTooManyRequestsRetryDelay.TotalMilliseconds));
+    }
+
+    private static TimeSpan GetNextTooManyRequestsRetryDelay(TimeSpan currentDelay)
+    {
+        return TimeSpan.FromMilliseconds(Math.Min(currentDelay.TotalMilliseconds * TooManyRequestsBackoffFactor, MaximumTooManyRequestsRetryDelay.TotalMilliseconds));
+    }
+
+    private static double GetRandomTooManyRequestsJitterMultiplier()
+    {
+        return 1 - TooManyRequestsJitterRatio + Random.Shared.NextDouble() * TooManyRequestsJitterRatio * 2;
     }
 
     private async Task<Result<TResponse>> GetResponse<TResponse>(string endpoint, HttpResponseMessage responseMessage, CancellationToken cancellationToken)

--- a/src/PostKit/Postmark/PostmarkRateLimiter.cs
+++ b/src/PostKit/Postmark/PostmarkRateLimiter.cs
@@ -7,33 +7,46 @@ namespace PostKit.Postmark;
 internal sealed class PostmarkRateLimiter(Func<TimeSpan, CancellationToken, Task>? delayAsync = null)
 {
     private static readonly TimeSpan RateLimitWindow = TimeSpan.FromSeconds(1);
+    private static readonly Dictionary<string, int> DefaultRateLimits = new(StringComparer.Ordinal)
+    {
+        ["email"] = 5000,
+        ["messages/outbound"] = 150,
+        ["message-streams/suppressions"] = 500,
+    };
+
     private readonly ConcurrentDictionary<string, RateLimitBucket> _buckets = new(StringComparer.Ordinal);
     private readonly Func<TimeSpan, CancellationToken, Task> _delayAsync = delayAsync ?? Task.Delay;
 
     public async Task<PostmarkRateLimitLease> WaitForAvailabilityAsync(string endpoint, CancellationToken cancellationToken)
     {
         var bucketKey = GetBucketKey(endpoint);
-        if (!_buckets.TryGetValue(bucketKey, out var bucket))
-            return new PostmarkRateLimitLease(bucketKey, false);
+        var bucket = _buckets.GetOrAdd(bucketKey, CreateBucket);
 
-        var delay = bucket.RecordRequestAndGetDelay();
-        if (delay > TimeSpan.Zero)
-            await _delayAsync(delay, cancellationToken);
+        var reservation = bucket.Reserve();
+        if (reservation.Delay > TimeSpan.Zero)
+            await _delayAsync(reservation.Delay, cancellationToken);
 
-        return new PostmarkRateLimitLease(bucketKey, true);
+        return new PostmarkRateLimitLease(bucketKey, reservation.Recorded);
     }
 
     public void ObserveResponse(string endpoint, HttpResponseHeaders headers, PostmarkRateLimitLease lease)
     {
-        if (!TryGetRateLimit(headers, out var limit))
+        if (!TryGetRateLimit(headers, out var limit, out var remaining))
             return;
 
         var bucketKey = string.IsNullOrEmpty(lease.BucketKey) ? GetBucketKey(endpoint) : lease.BucketKey;
-        var bucket = _buckets.GetOrAdd(bucketKey, static _ => new RateLimitBucket());
-        bucket.SetLimit(limit);
+        var bucket = _buckets.GetOrAdd(bucketKey, CreateBucket);
+        bucket.ObserveLimit(limit, remaining);
 
         if (!lease.Recorded)
             bucket.RecordObservedRequest();
+    }
+
+    public void ObserveTooManyRequests(string endpoint, TimeSpan retryDelay)
+    {
+        var bucketKey = GetBucketKey(endpoint);
+        var bucket = _buckets.GetOrAdd(bucketKey, CreateBucket);
+        bucket.BlockUntil(retryDelay);
     }
 
     public Task DelayAsync(TimeSpan delay, CancellationToken cancellationToken)
@@ -41,10 +54,23 @@ internal sealed class PostmarkRateLimiter(Func<TimeSpan, CancellationToken, Task
         return _delayAsync(delay, cancellationToken);
     }
 
-    private static bool TryGetRateLimit(HttpResponseHeaders headers, out int limit)
+    private static RateLimitBucket CreateBucket(string bucketKey)
+    {
+        return DefaultRateLimits.TryGetValue(bucketKey, out var limit) ? new RateLimitBucket(limit) : new RateLimitBucket();
+    }
+
+    private static bool TryGetRateLimit(HttpResponseHeaders headers, out int limit, out int? remaining)
     {
         limit = 0;
-        return TryGetPositiveIntHeader(headers, "RateLimit-Limit", out limit) || TryGetPositiveIntHeader(headers, "X-RateLimit-Limit-Second", out limit);
+        remaining = null;
+
+        if (!TryGetPositiveIntHeader(headers, "RateLimit-Limit", out limit) && !TryGetPositiveIntHeader(headers, "X-RateLimit-Limit-Second", out limit))
+            return false;
+
+        if (TryGetNonNegativeIntHeader(headers, "RateLimit-Remaining", out var standardRemaining) || TryGetNonNegativeIntHeader(headers, "X-RateLimit-Remaining-Second", out standardRemaining))
+            remaining = standardRemaining;
+
+        return true;
     }
 
     private static bool TryGetPositiveIntHeader(HttpResponseHeaders headers, string name, out int value)
@@ -56,6 +82,22 @@ internal sealed class PostmarkRateLimiter(Func<TimeSpan, CancellationToken, Task
         foreach (var headerValue in values)
         {
             if (int.TryParse(headerValue, out value) && value > 0)
+                return true;
+        }
+
+        value = 0;
+        return false;
+    }
+
+    private static bool TryGetNonNegativeIntHeader(HttpResponseHeaders headers, string name, out int value)
+    {
+        value = 0;
+        if (!headers.TryGetValues(name, out var values))
+            return false;
+
+        foreach (var headerValue in values)
+        {
+            if (int.TryParse(headerValue, out value) && value >= 0)
                 return true;
         }
 
@@ -85,13 +127,27 @@ internal sealed class PostmarkRateLimiter(Func<TimeSpan, CancellationToken, Task
         private readonly object _gate = new();
         private readonly Queue<long> _requestTimestamps = new();
         private int? _limit;
+        private long? _blockedUntilTimestamp;
 
-        public void SetLimit(int limit)
+        public RateLimitBucket(int? limit = null)
+        {
+            _limit = limit;
+        }
+
+        public void ObserveLimit(int limit, int? remaining)
         {
             lock (_gate)
             {
                 _limit = limit;
-                PruneOldRequests(Stopwatch.GetTimestamp());
+                var now = Stopwatch.GetTimestamp();
+                PruneOldRequests(now);
+
+                if (!remaining.HasValue)
+                    return;
+
+                var observedRequests = Math.Clamp(limit - remaining.Value, 0, limit);
+                while (_requestTimestamps.Count < observedRequests)
+                    _requestTimestamps.Enqueue(now);
             }
         }
 
@@ -105,36 +161,57 @@ internal sealed class PostmarkRateLimiter(Func<TimeSpan, CancellationToken, Task
             }
         }
 
-        public TimeSpan RecordRequestAndGetDelay()
+        public void BlockUntil(TimeSpan retryDelay)
         {
             lock (_gate)
             {
                 var now = Stopwatch.GetTimestamp();
-                PruneOldRequests(now);
-
-                if (_limit is null || _requestTimestamps.Count == 0)
-                {
-                    _requestTimestamps.Enqueue(now);
-                    return TimeSpan.Zero;
-                }
-
-                var targetRequestsPerWindow = Math.Max(1, _limit.Value - 1);
-                var oldest = _requestTimestamps.Peek();
-                var actualElapsedMilliseconds = GetElapsedMilliseconds(oldest, now);
-                var idealElapsedMilliseconds = (_requestTimestamps.Count + 1) * RateLimitWindow.TotalMilliseconds / targetRequestsPerWindow;
-                var delayMilliseconds = idealElapsedMilliseconds - actualElapsedMilliseconds;
-
-                if (delayMilliseconds <= 0)
-                {
-                    _requestTimestamps.Enqueue(now);
-                    return TimeSpan.Zero;
-                }
-
-                var roundedDelayMilliseconds = Math.Max(1, (int)Math.Ceiling(delayMilliseconds));
-                var delay = TimeSpan.FromMilliseconds(roundedDelayMilliseconds);
-                _requestTimestamps.Enqueue(AddDelay(now, delay));
-                return delay;
+                var blockedUntil = AddDelay(now, retryDelay);
+                if (!_blockedUntilTimestamp.HasValue || blockedUntil > _blockedUntilTimestamp.Value)
+                    _blockedUntilTimestamp = blockedUntil;
             }
+        }
+
+        public RateLimitReservation Reserve()
+        {
+            lock (_gate)
+            {
+                var now = Stopwatch.GetTimestamp();
+                var scheduledTimestamp = GetEarliestAvailableTimestamp(now);
+                PruneOldRequests(scheduledTimestamp);
+
+                if (_limit is null)
+                    return new RateLimitReservation(false, GetDelay(now, scheduledTimestamp));
+
+                if (_requestTimestamps.Count > 0)
+                {
+                    var targetRequestsPerWindow = Math.Max(1, _limit.Value - 1);
+                    var oldest = _requestTimestamps.Peek();
+                    var actualElapsedMilliseconds = GetElapsedMilliseconds(oldest, scheduledTimestamp);
+                    var idealElapsedMilliseconds = (_requestTimestamps.Count + 1) * RateLimitWindow.TotalMilliseconds / targetRequestsPerWindow;
+                    var delayMilliseconds = idealElapsedMilliseconds - actualElapsedMilliseconds;
+
+                    if (delayMilliseconds > 0)
+                        scheduledTimestamp = AddDelay(scheduledTimestamp, TimeSpan.FromMilliseconds(Math.Max(1, (int)Math.Ceiling(delayMilliseconds))));
+                }
+
+                _requestTimestamps.Enqueue(scheduledTimestamp);
+                return new RateLimitReservation(true, GetDelay(now, scheduledTimestamp));
+            }
+        }
+
+        private long GetEarliestAvailableTimestamp(long now)
+        {
+            if (!_blockedUntilTimestamp.HasValue)
+                return now;
+
+            if (_blockedUntilTimestamp.Value <= now)
+            {
+                _blockedUntilTimestamp = null;
+                return now;
+            }
+
+            return _blockedUntilTimestamp.Value;
         }
 
         private void PruneOldRequests(long now)
@@ -152,7 +229,14 @@ internal sealed class PostmarkRateLimiter(Func<TimeSpan, CancellationToken, Task
         {
             return timestamp + (long)Math.Ceiling(delay.TotalSeconds * Stopwatch.Frequency);
         }
+
+        private static TimeSpan GetDelay(long now, long scheduledTimestamp)
+        {
+            return scheduledTimestamp <= now ? TimeSpan.Zero : TimeSpan.FromMilliseconds(Math.Max(1, (int)Math.Ceiling(GetElapsedMilliseconds(now, scheduledTimestamp))));
+        }
     }
 }
+
+internal readonly record struct RateLimitReservation(bool Recorded, TimeSpan Delay);
 
 internal readonly record struct PostmarkRateLimitLease(string BucketKey, bool Recorded);

--- a/tests/PostKit.Tests/PostmarkClientErrorHandlingTests.cs
+++ b/tests/PostKit.Tests/PostmarkClientErrorHandlingTests.cs
@@ -158,6 +158,32 @@ public class PostmarkClientErrorHandlingTests
     }
 
     [Fact]
+    public async Task GetAsync_WithKnownRateLimitedEndpoint_DelaysColdSuccessiveCallsBeforeHeaders()
+    {
+        var delays = new List<TimeSpan>();
+        using var handler = new SequenceHttpMessageHandler(
+            CreateOkResponse(),
+            CreateOkResponse()
+        );
+        using var httpClient = new HttpClient(handler);
+        var rateLimiter = new PostmarkRateLimiter((delay, _) =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            }
+        );
+        var client = new PostmarkClient(httpClient, Options.Create(new PostKitOptions { ServerApiToken = "token" }), new TestLogger<PostmarkClient>(), rateLimiter);
+
+        var firstResult = await client.GetAsync<PostmarkResponse>("/messages/outbound?count=1", CancellationToken.None);
+        var secondResult = await client.GetAsync<PostmarkResponse>("/messages/outbound?count=1&offset=1", CancellationToken.None);
+
+        Assert.True(firstResult.IsSuccess(out _), firstResult.ToString());
+        Assert.True(secondResult.IsSuccess(out _), secondResult.ToString());
+        var delay = Assert.Single(delays);
+        Assert.True(delay >= TimeSpan.FromMilliseconds(1), $"Expected at least a 1 ms delay, received {delay.TotalMilliseconds} ms.");
+    }
+
+    [Fact]
     public async Task GetAsync_WithTooManyRequests_RetriesWithExponentialBackoff()
     {
         var delays = new List<TimeSpan>();
@@ -173,13 +199,74 @@ public class PostmarkClientErrorHandlingTests
                 return Task.CompletedTask;
             }
         );
-        var client = new PostmarkClient(httpClient, Options.Create(new PostKitOptions { ServerApiToken = "token" }), new TestLogger<PostmarkClient>(), rateLimiter);
+        var client = new PostmarkClient(httpClient, Options.Create(new PostKitOptions { ServerApiToken = "token" }), new TestLogger<PostmarkClient>(), rateLimiter, NoJitter);
 
         var result = await client.GetAsync<PostmarkResponse>("/bounces?count=1&offset=0", CancellationToken.None);
 
         Assert.True(result.IsSuccess(out _), result.ToString());
         Assert.Equal(3, handler.RequestCount);
-        Assert.Equal([TimeSpan.FromMilliseconds(100), TimeSpan.FromMilliseconds(200)], delays);
+        Assert.Equal([TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(2)], delays);
+    }
+
+    [Fact]
+    public async Task GetAsync_WithTooManyRequests_AppliesConfiguredJitter()
+    {
+        var delays = new List<TimeSpan>();
+        using var handler = new SequenceHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent("""{"ErrorCode":0,"Message":"OK"}""", Encoding.UTF8, MediaTypeNames.Application.Json) }
+        );
+        using var httpClient = new HttpClient(handler);
+        var rateLimiter = new PostmarkRateLimiter((delay, _) =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            }
+        );
+        var client = new PostmarkClient(httpClient, Options.Create(new PostKitOptions { ServerApiToken = "token" }), new TestLogger<PostmarkClient>(), rateLimiter, static () => 1.2);
+
+        var result = await client.GetAsync<PostmarkResponse>("/bounces?count=1&offset=0", CancellationToken.None);
+
+        Assert.True(result.IsSuccess(out _), result.ToString());
+        var delay = Assert.Single(delays);
+        Assert.Equal(TimeSpan.FromMilliseconds(1200), delay);
+    }
+
+    [Fact]
+    public async Task GetAsync_WithTooManyRequests_BlocksEndpointGroupOnly()
+    {
+        var delays = new List<TimeSpan>();
+        using var handler = new SequenceHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests),
+            CreateOkResponse(),
+            CreateOkResponse(),
+            CreateOkResponse()
+        );
+        using var httpClient = new HttpClient(handler);
+        var rateLimiter = new PostmarkRateLimiter((delay, _) =>
+            {
+                delays.Add(delay);
+                return Task.CompletedTask;
+            }
+        );
+        var client = new PostmarkClient(httpClient, Options.Create(new PostKitOptions { ServerApiToken = "token" }), new TestLogger<PostmarkClient>(), rateLimiter, NoJitter);
+
+        var detailsResult = await client.GetAsync<PostmarkResponse>("/messages/outbound/07311c54-0687-4ab9-b034-b54b5bad88ba/details", CancellationToken.None);
+
+        Assert.True(detailsResult.IsSuccess(out _), detailsResult.ToString());
+        var retryDelay = Assert.Single(delays);
+        Assert.Equal(TimeSpan.FromSeconds(1), retryDelay);
+
+        var suppressionsResult = await client.GetAsync<PostmarkResponse>("/message-streams/outbound/suppressions/dump", CancellationToken.None);
+
+        Assert.True(suppressionsResult.IsSuccess(out _), suppressionsResult.ToString());
+        Assert.Single(delays);
+
+        var searchResult = await client.GetAsync<PostmarkResponse>("/messages/outbound?count=1", CancellationToken.None);
+
+        Assert.True(searchResult.IsSuccess(out _), searchResult.ToString());
+        Assert.Equal(2, delays.Count);
+        Assert.True(delays[1] >= TimeSpan.FromMilliseconds(1), $"Expected the outbound message group to remain delayed, received {delays[1].TotalMilliseconds} ms.");
     }
 
     [Fact]
@@ -187,6 +274,7 @@ public class PostmarkClientErrorHandlingTests
     {
         var delays = new List<TimeSpan>();
         using var handler = new SequenceHttpMessageHandler(
+            new HttpResponseMessage(HttpStatusCode.TooManyRequests),
             new HttpResponseMessage(HttpStatusCode.TooManyRequests),
             new HttpResponseMessage(HttpStatusCode.TooManyRequests),
             new HttpResponseMessage(HttpStatusCode.TooManyRequests),
@@ -201,21 +289,22 @@ public class PostmarkClientErrorHandlingTests
                 return Task.CompletedTask;
             }
         );
-        var client = new PostmarkClient(httpClient, Options.Create(new PostKitOptions { ServerApiToken = "token" }), new TestLogger<PostmarkClient>(), rateLimiter);
+        var client = new PostmarkClient(httpClient, Options.Create(new PostKitOptions { ServerApiToken = "token" }), new TestLogger<PostmarkClient>(), rateLimiter, NoJitter);
 
         var result = await client.GetAsync<PostmarkResponse>("/bounces?count=1&offset=0", CancellationToken.None);
 
         Assert.True(result.IsFailure(out var error, out var _), result.ToString());
         var httpError = Assert.IsType<HttpError>(error);
         Assert.Equal(HttpStatusCode.TooManyRequests, httpError.StatusCode);
-        Assert.Equal(6, handler.RequestCount);
+        Assert.Equal(7, handler.RequestCount);
         Assert.Equal(
             [
-                TimeSpan.FromMilliseconds(100),
-                TimeSpan.FromMilliseconds(200),
-                TimeSpan.FromMilliseconds(400),
-                TimeSpan.FromMilliseconds(800),
-                TimeSpan.FromMilliseconds(1600),
+                TimeSpan.FromSeconds(1),
+                TimeSpan.FromSeconds(2),
+                TimeSpan.FromSeconds(4),
+                TimeSpan.FromSeconds(8),
+                TimeSpan.FromSeconds(16),
+                TimeSpan.FromSeconds(30),
             ],
             delays
         );
@@ -231,13 +320,28 @@ public class PostmarkClientErrorHandlingTests
 
     private static HttpResponseMessage CreateRateLimitedResponse(HttpStatusCode statusCode, int rateLimit)
     {
-        var response = new HttpResponseMessage(statusCode) { Content = new StringContent("""{"ErrorCode":0,"Message":"OK"}""", Encoding.UTF8, MediaTypeNames.Application.Json) };
+        var response = CreateResponse(statusCode);
         response.Headers.Add("RateLimit-Limit", rateLimit.ToString(CultureInfo.InvariantCulture));
         response.Headers.Add("RateLimit-Remaining", (rateLimit - 1).ToString(CultureInfo.InvariantCulture));
         response.Headers.Add("RateLimit-Reset", "1");
         response.Headers.Add("X-RateLimit-Limit-Second", rateLimit.ToString(CultureInfo.InvariantCulture));
         response.Headers.Add("X-RateLimit-Remaining-Second", (rateLimit - 1).ToString(CultureInfo.InvariantCulture));
         return response;
+    }
+
+    private static HttpResponseMessage CreateOkResponse()
+    {
+        return CreateResponse(HttpStatusCode.OK);
+    }
+
+    private static HttpResponseMessage CreateResponse(HttpStatusCode statusCode)
+    {
+        return new HttpResponseMessage(statusCode) { Content = new StringContent("""{"ErrorCode":0,"Message":"OK"}""", Encoding.UTF8, MediaTypeNames.Application.Json) };
+    }
+
+    private static double NoJitter()
+    {
+        return 1;
     }
 
     private sealed class SequenceHttpMessageHandler(params HttpResponseMessage[] responseMessages) : HttpMessageHandler, IDisposable


### PR DESCRIPTION
- Made Postmark rate limiting group-scoped for outbound messages, suppressions, and email endpoints.
- Seeded known endpoint group limits before response headers are observed to avoid cold-start bursts.
- Updated 429 handling to retry six times with exponential backoff from `1s` to `30s`, plus `±20%` jitter, scoped to the affected endpoint group.
- Updated package version metadata to `10.1.6` / `10.1.6.0`.
- Validated with `dotnet test tests\PostKit.Tests\PostKit.Tests.csproj --framework net10.0`.