### PR TITLE
Fixed outbound message details raw body handling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,7 @@ if (messagesResult.IsSuccess(out var page))
 ```
 
 Outbound message date filters accept `DateTimeOffset` values and are converted to Postmark's US Eastern time before the request is made. Postmark currently supports one metadata filter per outbound message search.
-Outbound message details expose nullable `TextBody` and `HtmlBody` properties because Postmark returns `null` for content variants that were not present on the sent message.
+Outbound message details expose nullable `TextBody`, `HtmlBody`, and `Body` properties because Postmark can omit content variants or the raw source on the details response. Use `GetOutboundMessageDumpAsync` when you specifically need the raw source.
 
 ### Suppressions
 

--- a/src/PostKit/Messages/OutboundMessageDetails.cs
+++ b/src/PostKit/Messages/OutboundMessageDetails.cs
@@ -12,8 +12,8 @@ public sealed record OutboundMessageDetails : OutboundMessage
     /// <summary>Gets the HTML body of the message, when the message has one.</summary>
     public string? HtmlBody { [UsedImplicitly] get; }
 
-    /// <summary>Gets the raw source of the message.</summary>
-    public string Body { [UsedImplicitly] get; }
+    /// <summary>Gets the raw source of the message, when Postmark returns it.</summary>
+    public string? Body { [UsedImplicitly] get; }
 
     /// <summary>Gets the events Postmark has recorded for the message.</summary>
     public IReadOnlyCollection<OutboundMessageEvent> MessageEvents { [UsedImplicitly] get; }
@@ -37,7 +37,7 @@ public sealed record OutboundMessageDetails : OutboundMessage
         bool sandboxed,
         string? textBody,
         string? htmlBody,
-        string body,
+        string? body,
         IReadOnlyCollection<OutboundMessageEvent> messageEvents
     )
         : base(tag, messageId, messageStream, to, cc, bcc, recipients, receivedAt, from, subject, attachments, status, trackOpens, trackLinks, metadata, sandboxed)

--- a/src/PostKit/PostKit.csproj
+++ b/src/PostKit/PostKit.csproj
@@ -28,9 +28,9 @@
     <!-- Output -->
     <PropertyGroup>
         <AssemblyName>PostKit</AssemblyName>
-        <Version>10.1.6</Version>
-        <AssemblyVersion>10.1.6.0</AssemblyVersion>
-        <FileVersion>10.1.6.0</FileVersion>
+        <Version>10.1.7</Version>
+        <AssemblyVersion>10.1.7.0</AssemblyVersion>
+        <FileVersion>10.1.7.0</FileVersion>
         <NeutralLanguage>en-US</NeutralLanguage>
         <Optimize>true</Optimize>
         <!--<IsAotCompatible>true</IsAotCompatible>-->

--- a/src/PostKit/PostKitClient.Messages.cs
+++ b/src/PostKit/PostKitClient.Messages.cs
@@ -323,9 +323,6 @@ internal sealed partial class PostKitClient
         if (mappedCore.IsFailure(out var error, out var outboundMessageCore))
             return Result.Failure<OutboundMessageDetails>(error);
 
-        if (response.Body is null)
-            return Result.Failure<OutboundMessageDetails>("Body was not returned from the Postmark Messages API.");
-
         if (response.MessageEvents is null)
             return Result.Failure<OutboundMessageDetails>("MessageEvents were not returned from the Postmark Messages API.");
 

--- a/tests/PostKit.Tests/PostKitClientMessageResponseTests.cs
+++ b/tests/PostKit.Tests/PostKitClientMessageResponseTests.cs
@@ -291,18 +291,20 @@ public class PostKitClientMessageResponseTests
     }
 
     [Fact]
-    public async Task GetOutboundMessageDetailsAsync_WhenBodyIsMissing_ReturnsHelpfulFailure()
+    public async Task GetOutboundMessageDetailsAsync_WhenBodyIsMissing_MapsNullableBody()
     {
         var messageId = Guid.Parse("07311c54-0687-4ab9-b034-b54b5bad88ba");
         const string endpoint = "/messages/outbound/07311c54-0687-4ab9-b034-b54b5bad88ba/details";
-        var responseJson = SuccessfulDetailsResponseJson.Replace("\"Body\": \"SMTP dump data\"", "\"Body\": null", StringComparison.Ordinal);
+        var responseJson = SuccessfulDetailsResponseJson.Replace("\"Body\": \"SMTP dump data\",", "", StringComparison.Ordinal);
         var postmark = new RecordingPostmarkClient(new Dictionary<string, string> { [endpoint] = responseJson });
         var client = new PostKitClient(postmark, new TestLogger());
 
         var result = await client.GetOutboundMessageDetailsAsync(messageId, CancellationToken.None);
 
-        Assert.True(result.IsFailure(out var error, out var _), result.ToString());
-        Assert.Equal("Body was not returned from the Postmark Messages API.", error.Message);
+        Assert.True(result.IsSuccess(out var response), result.ToString());
+        Assert.Null(response.Body);
+        Assert.Equal("Thank you for your order...", response.TextBody);
+        Assert.Equal("<p>Thank you for your order...</p>", response.HtmlBody);
     }
 
     [Fact]


### PR DESCRIPTION
- Fixed outbound message details mapping so a missing raw `Body` is treated as absent optional details content instead of failing the entire response.
- Made `OutboundMessageDetails.Body` nullable and documented `GetOutboundMessageDumpAsync` as the API to use when raw source is required.
- Updated package version metadata to `10.1.7` / `10.1.7.0`.
- Validated with `dotnet test tests\PostKit.Tests\PostKit.Tests.csproj --framework net10.0`.